### PR TITLE
Input and mapping fixes

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -456,6 +456,13 @@ static bool input_handle_mapping_event(struct input_event *ev, struct input_devi
   return true;
 }
 
+static void input_drain(void) {
+  for (int i = 0; i < numDevices; i++) {
+    struct input_event ev;
+    while (libevdev_next_event(devices[i].dev, LIBEVDEV_READ_FLAG_NORMAL, &ev) >= 0);
+  }
+}
+
 static void input_poll(bool (*handler) (struct input_event*, struct input_device*)) {
   while (poll(fds, numFds, -1)) {
     if (fds[udev_fdindex].revents > 0) {
@@ -501,19 +508,23 @@ static void input_map_key(char* keyName, short* key) {
   currentAbs = NULL;
   *key = -1;
   input_poll(input_handle_mapping_event);
+  usleep(250000);
+  input_drain();
 }
 
 static void input_map_abs(char* keyName, short* abs, bool* reverse) {
-  printf("%s\n", keyName);
+  printf("Move %s\n", keyName);
   currentKey = NULL;
   currentAbs = abs;
   currentReverse = reverse;
   *abs = -1;
   input_poll(input_handle_mapping_event);
+  usleep(250000);
+  input_drain();
 }
 
 static void input_map_abskey(char* keyName, short* key, short* abs, bool* reverse) {
-  printf("%s\n", keyName);
+  printf("Press %s\n", keyName);
   currentKey = key;
   currentAbs = abs;
   currentReverse = reverse;
@@ -521,6 +532,8 @@ static void input_map_abskey(char* keyName, short* key, short* abs, bool* revers
   *abs = -1;
   *currentReverse = false;
   input_poll(input_handle_mapping_event);
+  usleep(250000);
+  input_drain();
 }
 
 void input_map(char* fileName) {

--- a/src/input.c
+++ b/src/input.c
@@ -347,12 +347,12 @@ static bool input_handle_event(struct input_event *ev, struct input_device *dev)
           gamepadCode = SPECIAL_FLAG;
       }
 
-      if (mouseCode > 0) {
+      if (mouseCode != 0) {
         LiSendMouseButtonEvent(ev->value?BUTTON_ACTION_PRESS:BUTTON_ACTION_RELEASE, mouseCode);
       } else {
         gamepadModified = true;
 
-        if (gamepadCode > 0) {
+        if (gamepadCode != 0) {
           if (ev->value)
             dev->buttonFlags |= gamepadCode;
           else

--- a/src/input.c
+++ b/src/input.c
@@ -110,6 +110,7 @@ void input_create(const char* device, char* mapFile) {
     exit(EXIT_FAILURE);
   }
 
+  memset(&devices[dev], 0, sizeof(devices[0]));
   devices[dev].fd = fd;
   devices[dev].dev = libevdev_new();
   libevdev_set_fd(devices[dev].dev, devices[dev].fd);

--- a/src/input.c
+++ b/src/input.c
@@ -34,6 +34,7 @@
 #include <fcntl.h>
 #include <poll.h>
 #include <limits.h>
+#include <unistd.h>
 
 struct input_abs_parms {
   int min, max;
@@ -51,7 +52,7 @@ struct input_device {
   __s32 mouseDeltaX, mouseDeltaY, mouseScroll;
   short controllerId;
   int buttonFlags;
-  short leftTrigger, rightTrigger;
+  char leftTrigger, rightTrigger;
   short leftStickX, leftStickY;
   short rightStickX, rightStickY;
   bool gamepadModified;
@@ -162,7 +163,8 @@ void input_init(char* mapfile) {
     exit(1);
   }
 
-  if (autoadd = numDevices == 0) {
+  autoadd = (numDevices == 0);
+  if (autoadd) {
     struct udev_enumerate *enumerate = udev_enumerate_new(udev);
     udev_enumerate_add_match_subsystem(enumerate, "input");
     udev_enumerate_scan_devices(enumerate);
@@ -356,9 +358,9 @@ static bool input_handle_event(struct input_event *ev, struct input_device *dev)
           else
             dev->buttonFlags &= ~gamepadCode;
         } else if (ev->code == dev->map.btn_tl2)
-          dev->leftTrigger = ev->value?USHRT_MAX:0;
+          dev->leftTrigger = ev->value?UCHAR_MAX:0;
         else if (ev->code == dev->map.btn_tr2)
-          dev->rightTrigger = ev->value?USHRT_MAX:0;
+          dev->rightTrigger = ev->value?UCHAR_MAX:0;
         else
           gamepadModified = false;
       }


### PR DESCRIPTION
Fixes the Y button problem. Drains the input queue between mappings to prevent queued input events from being picked up on the next mapping. Warning fixes and a mapping message change.