### PR TITLE
Fix 'implicit declaration of function' compiler warning

### DIFF
--- a/src/global.c
+++ b/src/global.c
@@ -17,6 +17,7 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <stdio.h>
 #include <signal.h>
 #include <pthread.h>
 


### PR DESCRIPTION
See comments on commit https://github.com/irtimmer/moonlight-embedded/commit/b84d11072c3f74ec7da5d0f617c1bc3f971dee78