### PR TITLE
Memory corruption and build fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ add_executable(moonlight ${SRC_LIST})
 set_property(TARGET moonlight PROPERTY C_STANDARD 11)
 
 if(BROADCOM_FOUND)
-  include_directories(./ilclient ./h264bitstream ${BROADCOM_INCLUDE_DIRS})
+  include_directories(./third_party/ilclient ./third_party/h264bitstream ${BROADCOM_INCLUDE_DIRS})
   target_link_libraries (moonlight PUBLIC ${BROADCOM_LIBRARIES})
   list(APPEND MOONLIGHT_DEFINITIONS ${BROADCOM_DEFINITIONS})
 endif()

--- a/src/input.c
+++ b/src/input.c
@@ -200,7 +200,7 @@ void input_init(char* mapfile) {
   sig_fdindex = numFds++;
 
   if (fds == NULL)
-    fds = malloc(sizeof(struct pollfd));
+    fds = malloc(sizeof(struct pollfd)*numFds);
   else
     fds = realloc(fds, sizeof(struct pollfd)*numFds);
 


### PR DESCRIPTION
The OMX build wasn't working because the include path was broken since the move to the third_party folder.

There is a memory corruption fixed if no input devices were opened at startup.