### PR TITLE
Common-C API 1.1 and GFE 2.4.5.54 support

### DIFF
--- a/src/audio.c
+++ b/src/audio.c
@@ -71,7 +71,7 @@ static void audio_renderer_init() {
   CHECK_RETURN(snd_pcm_prepare(handle));
 }
 
-static void audio_renderer_release() {
+static void audio_renderer_cleanup() {
   if (decoder != NULL)
     opus_decoder_destroy(decoder);
 
@@ -99,8 +99,6 @@ static void audio_renderer_decode_and_play_sample(char* data, int length) {
 
 AUDIO_RENDERER_CALLBACKS audio_callbacks = {
   .init = audio_renderer_init,
-  .start = NULL,
-  .stop = NULL,
-  .release = audio_renderer_release,
+  .cleanup = audio_renderer_cleanup,
   .decodeAndPlaySample = audio_renderer_decode_and_play_sample,
 };

--- a/src/client.c
+++ b/src/client.c
@@ -124,7 +124,10 @@ static void client_load_server_status(const char *address) {
 
   paired = pairedText != NULL && strcmp(pairedText, "1") == 0;
   currentGame = currentGameText == NULL ? 0 : atoi(currentGameText);
-  strstr(versionText, ".")[0] = 0;
+  char *versionSep = strstr(versionText, ".");
+  if (versionSep != NULL) {
+    *versionSep = 0;
+  }
   serverMajorVersion = atoi(versionText);
 
   free(pairedText);
@@ -306,7 +309,7 @@ void client_pair(const char *address) {
   sprintf(url, "https://%s:47984/pair?uniqueid=%s&devicename=roth&updateState=1&clientpairingsecret=%s", address, unique_id, client_pairing_secret_hex);
   http_request(url, data);
 
-  sprintf(url, "https://%s:47984/pair?uniqueid=%s&devicename=roth&updateState=1&phrase=pairchallenge", address, unique_id, challenge_response_hex);
+  sprintf(url, "https://%s:47984/pair?uniqueid=%s&devicename=roth&updateState=1&phrase=pairchallenge", address, unique_id);
   http_request(url, data);
   http_free_data(data);
 

--- a/src/main.c
+++ b/src/main.c
@@ -61,19 +61,7 @@ static void stream(STREAM_CONFIGURATION* config, const char* address, const char
 
   video_init();
 
-  struct addrinfo hints, *res;
-  memset(&hints, 0, sizeof(hints));
-  hints.ai_family = AF_INET;
-  hints.ai_socktype = SOCK_STREAM;
-  int err = getaddrinfo(address, NULL, &hints, &res);
-  if (err<0 || res == NULL) {
-    fprintf(stderr, "Can't resolve host: %s\n", address);
-    exit(-1);
-  }
-
-  struct sockaddr_in *addr = (struct sockaddr_in*)res->ai_addr;
-  LiStartConnection(addr->sin_addr.s_addr, config, &connection_callbacks, decoder_callbacks, &audio_callbacks, NULL, NULL, 0, client_get_server_version());
-  freeaddrinfo(res);
+  LiStartConnection(address, config, &connection_callbacks, decoder_callbacks, &audio_callbacks, NULL, NULL, 0, client_get_server_version());
 
   input_loop();
 

--- a/src/video/fake.c
+++ b/src/video/fake.c
@@ -28,7 +28,7 @@ void decoder_renderer_setup(int width, int height, int redrawRate, void* context
   fd = fopen(fileName, "w");
 }
 
-void decoder_renderer_release() {
+void decoder_renderer_cleanup() {
   fclose(fd);
 }
 
@@ -43,8 +43,6 @@ int decoder_renderer_submit_decode_unit(PDECODE_UNIT decodeUnit) {
 
 DECODER_RENDERER_CALLBACKS decoder_callbacks_fake = {
   .setup = decoder_renderer_setup,
-  .start = NULL,
-  .stop = NULL,
-  .release = decoder_renderer_release,
+  .cleanup = decoder_renderer_cleanup,
   .submitDecodeUnit = decoder_renderer_submit_decode_unit,
 };

--- a/src/video/imx.c
+++ b/src/video/imx.c
@@ -412,7 +412,7 @@ static int decoder_renderer_submit_decode_unit(PDECODE_UNIT decodeUnit) {
   return DR_OK;
 }
 
-static void decoder_renderer_release() {
+static void decoder_renderer_cleanup() {
   IOFreePhyMem(&ps_mem_desc);
   IOFreePhyMem(&slice_mem_desc);
   
@@ -423,8 +423,6 @@ static void decoder_renderer_release() {
 
 DECODER_RENDERER_CALLBACKS decoder_callbacks_imx = {
   .setup = decoder_renderer_setup,
-  .start = NULL,
-  .stop = NULL,
-  .release = decoder_renderer_release,
+  .cleanup = decoder_renderer_cleanup,
   .submitDecodeUnit = decoder_renderer_submit_decode_unit,
 };

--- a/src/video/omx.c
+++ b/src/video/omx.c
@@ -130,7 +130,7 @@ static void decoder_renderer_setup(int width, int height, int redrawRate, void* 
   }
 }
 
-static void decoder_renderer_stop() {
+static void decoder_renderer_cleanup() {
   int status = 0;
 
   buf->nFilledLen = 0;
@@ -145,9 +145,7 @@ static void decoder_renderer_stop() {
   ilclient_flush_tunnels(tunnel, 0);
 
   ilclient_disable_port_buffers(list[0], 130, NULL, NULL, NULL);
-}
 
-static void decoder_renderer_release() {
   ilclient_disable_tunnel(tunnel);
   ilclient_teardown_tunnels(tunnel);
 
@@ -228,8 +226,6 @@ static int decoder_renderer_submit_decode_unit(PDECODE_UNIT decodeUnit) {
 
 DECODER_RENDERER_CALLBACKS decoder_callbacks_omx = {
   .setup = decoder_renderer_setup,
-  .start = NULL,
-  .stop = decoder_renderer_stop,
-  .release = decoder_renderer_release,
+  .cleanup = decoder_renderer_cleanup,
   .submitDecodeUnit = decoder_renderer_submit_decode_unit,
 };

--- a/src/xml.c
+++ b/src/xml.c
@@ -92,7 +92,7 @@ int xml_search(char* data, size_t len, char* node, char** result) {
   struct xml_query search;
   search.data = node;
   search.start = 0;
-  search.memory = malloc(1);
+  search.memory = calloc(1, 1);
   search.size = 0;
   XML_Parser parser = XML_ParserCreate("UTF-8");
   XML_SetUserData(parser, &search);
@@ -110,7 +110,7 @@ int xml_search(char* data, size_t len, char* node, char** result) {
 
 struct app_list* xml_applist(char* data, size_t len) {
   struct xml_query query;
-  query.memory = malloc(1);
+  query.memory = calloc(1, 1);
   query.size = 0;
   query.start = 0;
   query.data = NULL;


### PR DESCRIPTION
This PR updates to the simplified API 1.1 version of common-c with IPv6 support and DNS resolution built-in. I also fixed a problem resulting in a segfault when pairing with GFE 2.4.5.54.