### PR TITLE
Improve handling and reporting of common errors

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -252,7 +252,7 @@ int main(int argc, char* argv[]) {
     address[0] = 0;
     discover_server(address);
     if (address[0] == 0) {
-      perror("Can't find server");
+      fprintf(stderr, "Autodiscovery failed. Specify an IP address next time.\n");
       exit(-1);
     }
   }


### PR DESCRIPTION
Fixes some rough edges reported in #143 

"Can't find server: Resource temporarily unavailable" becomes "Autodiscovery failed. Specify an IP address next time." to be less confusing if Avahi isn't installed.

The moonlight-common-c change adds more failure logging for troubleshooting. RTSP now returns more useful error codes than -1.