### PR TITLE
Input fixes (and a pairing check)

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -227,6 +227,11 @@ void client_pair(const char *address) {
     return;
   }
 
+  if (currentGame != 0) {
+    fprintf(stderr, "The computer is currently in a game. You must close the game before pairing.\n");
+    exit(-1);
+  }
+
   char pin[5];
   sprintf(pin, "%d%d%d%d", (int)random() % 10, (int)random() % 10, (int)random() % 10, (int)random() % 10);
   printf("Please enter the following PIN on the target PC: %s\n", pin);

--- a/src/input.c
+++ b/src/input.c
@@ -236,11 +236,15 @@ static void input_remove(int devindex) {
   if (fdindex != numFds && numFds > 0) {
     memcpy(&fds[fdindex], &fds[numFds], sizeof(struct pollfd));
     if (numFds == udev_fdindex)
-      udev_fdindex = numFds;
+      udev_fdindex = fdindex;
+    else if (numFds == sig_fdindex)
+      sig_fdindex = fdindex;
     else {
       for (int i=0;i<numDevices;i++) {
-        if (devices[i].fdindex == numFds)
+        if (devices[i].fdindex == numFds) {
           devices[i].fdindex = fdindex;
+          break;
+        }
       }
     }
   }
@@ -483,7 +487,7 @@ static bool input_handle_event(struct input_event *ev, struct input_device *dev)
       case REL_Y:
         dev->mouseDeltaY = ev->value;
         break;
-      case REL_Z:
+      case REL_WHEEL:
         dev->mouseScroll = ev->value;
         break;
     }


### PR DESCRIPTION
Pairing check:
Pairing when a computer was in game was pretty messed up. It would display the code then immediately say "Paired" since the responses are never checked for success. When you try to stream, it would tell you to pair (which is pretty confusing).

Input hotplugging:
There was a typo and forgotten handling of sig_fdindex which was causing problems with input device hotplugging. If a device was added before the stream started (lower index than sig_fdindex) it would cause problems when it was removed and readded (higher index than sig_fdindex) because sig_fdindex was never moved. As a result, input devices present at startup but unplugged after the stream started and plugged back in wouldn't be active until streaming was restarted.

Scrolling fixes:
The correct input code is REL_WHEEL for wheel input. There was also a bug in common-c where the parameter to LiSendScrollEvent was treated as unsigned (because char can be signed or unsigned by default depending on the implementation). This led to some broken math and broken backwards scrolling.
