### PR TITLE
Added somewhat effective stdin cleanup.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -275,6 +275,11 @@ int main(int argc, char* argv[]) {
     input_init(mapping);
     pair_check();
     stream(&config, address, app, sops, localaudio);
+    char cbuffer;
+    printf("Clearing up stdin... Press Ctrl-C when Ready to Quit.");
+    while (cbuffer = getchar()) {
+	}
+    printf("done");
   } else if (strcmp("pair", action) == 0)
     client_pair(address);
   else if (strcmp("quit", action) == 0) {
@@ -283,3 +288,4 @@ int main(int argc, char* argv[]) {
   } else
     fprintf(stderr, "%s is not a valid action\n", action);
 }
+


### PR DESCRIPTION
This should somewhat help prevent user's from accidentally executing dangerous commands into the terminal...  

Unfortunately comparing getchar() to EOF doesn't work when you are talking about the system stdin buffer since it is always expecting more input.

At least this will clean up alot of characters before the user presses the Ctrl-C.

Hopefully this can be implemented.. and then greatly expanded on.
