### PR TITLE
Grab input devices to avoid console input

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ For a demo see this [video](https://www.youtube.com/watch?v=XRW6O0bSHNw).
 	-audio <device> Use <device> as ALSA audio output device (default sysdefault)
 	-localaudio Play audio locally
 
-	Use ctrl-c to exit application
+	Use Ctrl+Alt+Shift+Q to exit streaming session
 
 ## Packages
 Prebuilt binary packages for Raspbian Wheezy are available, add this line to your */etc/apt/sources.list*

--- a/src/main.c
+++ b/src/main.c
@@ -91,7 +91,8 @@ static void help() {
   printf("\t-input <device>\t\tUse <device> as input. Can be used multiple times\n");
   printf("\t-mapping <file>\t\tUse <file> as gamepad mapping configuration file (use before -input)\n");
   printf("\t-audio <device>\t\tUse <device> as ALSA audio output device (default sysdefault)\n");
-  printf("\t-localaudio\t\tPlay audio locally\n");
+  printf("\t-localaudio\t\tPlay audio locally\n\n");
+  printf("Use Ctrl+Alt+Shift+Q to exit streaming session\n\n");
   exit(0);
 }
 


### PR DESCRIPTION
This change uses EVIOCGRAB to exclusively grab input devices (if possible). This means Ctrl+C doesn't work anymore, so I wrote code to allow a defined combination (currently Ctrl+Alt+Shift+Q like Moonlight-PC) to quit the stream. I moved the SIGBLOCK to right before starting the input polling because I found in my testing that Ctrl+C wasn't working while the connection was being established since the input loop wasn't running yet.