### PR TITLE
OSMC support

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/irtimmer/moonlight-embedded
 
 Package: moonlight-embedded
 Architecture: armhf
-Depends: libopus0, libexpat1, libssl1.0.0, libasound2, libudev0, libavahi-client3, libcurl3, libevdev2, libraspberrypi0, ${shlibs:Depends}, ${misc:Depends}
+Depends: libopus0, libexpat1, libssl1.0.0, libasound2, libudev0, libavahi-client3, libcurl3, libevdev2, libraspberrypi0 | rbp-userland-osmc, ${shlibs:Depends}, ${misc:Depends}
 Description: GameStream client for Linux
  Game streaming client for Nvidia's GameStream.
  Stream games from your Windows computer with Nvidia graphic card to your linux box.

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: moonlight-embedded
 Section: games
 Priority: extra
 Maintainer: Iwan Timmer <irtimmer@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), cmake, libopus-dev, libexpat1-dev, libasound2-dev, libudev-dev, libavahi-client-dev, libcurl4-openssl-dev, libevdev-dev, libraspberrypi-dev
+Build-Depends: debhelper (>= 8.0.0), cmake, libopus-dev, libexpat1-dev, libasound2-dev, libudev-dev, libavahi-client-dev, libcurl4-openssl-dev, libevdev-dev, libraspberrypi-dev | rbp-userland-dev-osmc
 Standards-Version: 3.9.3
 Homepage: https://github.com/irtimmer/moonlight-embedded
 


### PR DESCRIPTION
Add ```rbp-userland-osmc``` as an alternative to ```libraspberrypi0``` in the dependencies and ```rbp-userland-dev-osmc``` as an alternative to ```libraspberrypi-dev``` in the build-dependencies to provide better support for OSMC.