### PR TITLE
Fix heap corruption in SPS processing

### DIFF
--- a/src/video/omx.c
+++ b/src/video/omx.c
@@ -133,6 +133,11 @@ static void decoder_renderer_setup(int width, int height, int redrawRate, void* 
 static void decoder_renderer_cleanup() {
   int status = 0;
 
+  if((buf = ilclient_get_input_buffer(video_decode, 130, 1)) == NULL){
+    fprintf(stderr, "Can't get video buffer\n");
+    exit(EXIT_FAILURE);
+  }
+
   buf->nFilledLen = 0;
   buf->nFlags = OMX_BUFFERFLAG_TIME_UNKNOWN | OMX_BUFFERFLAG_EOS;
 

--- a/src/video/omx.c
+++ b/src/video/omx.c
@@ -192,14 +192,15 @@ static int decoder_renderer_submit_decode_unit(PDECODE_UNIT decodeUnit) {
     stream->sps->vui.num_reorder_frames = 0;
     stream->sps->vui.max_dec_frame_buffering = 1;
 
-    entry->length = write_nal_unit(stream, entry->data+4, entry->length*2) + 4;
-  }
-
-  while (entry != NULL) {
-    memcpy(dest, entry->data, entry->length);
-    buf->nFilledLen += entry->length;
-    dest += entry->length;
-    entry = entry->next;
+    memcpy(dest, entry->data, 4);
+    buf->nFilledLen = write_nal_unit(stream, dest+4, 128) + 4;
+  } else {
+    while (entry != NULL) {
+      memcpy(dest, entry->data, entry->length);
+      buf->nFilledLen += entry->length;
+      dest += entry->length;
+      entry = entry->next;
+    }
   }
 
   if(port_settings_changed == 0 &&


### PR DESCRIPTION
entry->data is only large enough to store the original SPS. The modified SPS can be much larger due to the extra bitstream_restrictions data.

Added a fix for null pointer dereference if the connection terminates immediately.
