### PR TITLE
Fix streaming on embedded devices

### DIFF
--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -50,6 +50,34 @@ static EVP_PKEY *privateKey;
 
 const char* gs_error;
 
+static int mkdirtree(const char* directory) {
+  char buffer[1024];
+  char* p = buffer;
+
+  // The passed in string could be a string literal
+  // so we must copy it first
+  strcpy(p, directory);
+
+  while (*p != 0) {
+    // Find the end of the path element
+    do {
+      p++;
+    } while (*p != 0 && *p != '/');
+
+    char oldChar = *p;
+    *p = 0;
+
+    // Create the directory if it doesn't exist already
+    if (mkdir(buffer, 0775) == -1 && errno != EEXIST) {
+        return -1;
+    }
+
+    *p = oldChar;
+  }
+
+  return 0;
+}
+
 static int load_unique_id(const char* keyDirectory) {
   char uniqueFilePath[4096];
   sprintf(uniqueFilePath, "%s/%s", keyDirectory, UNIQUE_FILE_NAME);
@@ -416,7 +444,7 @@ int gs_quit_app(PSERVER_DATA server) {
 }
 
 int gs_init(PSERVER_DATA server, const char *keyDirectory) {
-  mkdir(keyDirectory, 00755);
+  mkdirtree(keyDirectory);
   if (load_unique_id(keyDirectory) != GS_OK)
     return GS_FAILED;
 

--- a/libgamestream/sps.c
+++ b/libgamestream/sps.c
@@ -34,14 +34,15 @@ void gs_sps_init(int width, int height) {
 
 PLENTRY gs_sps_fix(PLENTRY *head, int flags) {
   PLENTRY entry = *head;
+  const char naluHeader[] = {0x00, 0x00, 0x00, 0x01};
+
   if (replay_sps == 1) {
     PLENTRY replay_entry = (PLENTRY) malloc(sizeof(*replay_entry) + 128);
     if (replay_entry == NULL)
       return NULL;
 
     replay_entry->data = (char *) (entry + 1);
-    char spsData[] = {0x00, 0x00, 0x00, 0x01, 0x67};
-    memcpy(replay_entry->data, spsData, sizeof(spsData));
+    memcpy(replay_entry->data, naluHeader, sizeof(naluHeader));
     h264_stream->sps->profile_idc = H264_PROFILE_HIGH;
     replay_entry->length = write_nal_unit(h264_stream, replay_entry->data+4, 124) + 4;
 
@@ -100,9 +101,9 @@ PLENTRY gs_sps_fix(PLENTRY *head, int flags) {
 
     PLENTRY next = entry->next;
     free(entry);
-    sps_entry->data = (char*) (entry + 1);
+    sps_entry->data = (char*) (sps_entry + 1);
+    memcpy(sps_entry->data, naluHeader, sizeof(naluHeader));
     sps_entry->length = write_nal_unit(h264_stream, sps_entry->data+4, 124) + 4;
-    printf("Writen %d\n", sps_entry->length);
     sps_entry->next = next;
     entry = sps_entry;
   } else if ((entry->data[4] & 0x1F) == NAL_UNIT_TYPE_PPS) {

--- a/src/loop.c
+++ b/src/loop.c
@@ -107,7 +107,6 @@ void loop_main() {
         if (ret == LOOP_RETURN) {
           return;
         }
-        break;
       }
     }
   }

--- a/src/main.c
+++ b/src/main.c
@@ -92,7 +92,9 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, enum platform sys
   LiStartConnection(server->address, &config->stream, &connection_callbacks, platform_get_video(system), platform_get_audio(system), context, 0, server->serverMajorVersion);
 
   if (IS_EMBEDDED(system))
+    evdev_start();
     loop_main();
+    evdev_stop();
   #ifdef HAVE_SDL
   else if (system == SDL)
     sdl_loop();

--- a/src/platform.c
+++ b/src/platform.c
@@ -37,7 +37,7 @@ enum platform platform_check(char* name) {
   #endif
   #ifdef HAVE_IMX
   if (std || strcmp(name, "imx") == 0) {
-    void *handle = dlopen("libmoonlight-imx.so", RTLD_NOW);
+    void *handle = dlopen("libmoonlight-imx.so", RTLD_NOW | RTLD_GLOBAL);
     ImxInit video_imx_init = (ImxInit) dlsym(RTLD_DEFAULT, "video_imx_init");
     if (handle != NULL) {
       if (video_imx_init())
@@ -47,7 +47,7 @@ enum platform platform_check(char* name) {
   #endif
   #ifdef HAVE_PI
   if (std || strcmp(name, "pi") == 0) {
-    void *handle = dlopen("libmoonlight-pi.so", RTLD_NOW);
+    void *handle = dlopen("libmoonlight-pi.so", RTLD_NOW | RTLD_GLOBAL);
     if (handle != NULL && dlsym(RTLD_DEFAULT, "bcm_host_init") != NULL)
       return PI;
   }

--- a/src/platform.c
+++ b/src/platform.c
@@ -87,10 +87,8 @@ AUDIO_RENDERER_CALLBACKS* platform_get_audio(enum platform system) {
   case SDL:
     return &audio_callbacks_sdl;
   #endif
-  #ifdef HAVE_FAKE
   default:
     return &audio_callbacks_alsa;
-  #endif
   }
   return NULL;
 }


### PR DESCRIPTION
Moonlight v2.1 broke streaming on embedded devices without SDL. This PR fixes all the bugs I found trying to make it work.

Fixes:
- Fix creation of the key directory which causes Moonlight to fail when starting up if not present (rm -rf ~/.cache can reproduce this issue)
- Fix platform library detection bug caused by not loading the library in the global space
- Fix missing ALSA audio support in release builds
- Fix broken input grabbing functionality (EVIOCGRAB)
- Remove an early break that led to fds being left without being read (causing udev's fd to be unread)
- Fix use-after-free bug in the SPS code for the Pi