### PR TITLE
cmake-2.8 compatibility work (debian wheezy)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 2.8.11)
 SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 include(${CMAKE_ROOT}/Modules/GNUInstallDirs.cmake)
 
+# include C99 helper macro
+include(cmake/use_c99.cmake)
+
 set(MOONLIGHT_MAJOR_VERSION 2)
 set(MOONLIGHT_MINOR_VERSION 1)
 set(MOONLIGHT_PATCH_VERSION 0)
@@ -53,7 +56,7 @@ add_subdirectory(libgamestream)
 
 add_executable(moonlight ${SRC_LIST})
 target_link_libraries(moonlight gamestream)
-set_property(TARGET moonlight PROPERTY C_STANDARD 99)
+use_c99(moonlight)
 
 if (CEC_FOUND AND CEC_VERSION_COMPATIBLE)
   list(APPEND MOONLIGHT_DEFINITIONS HAVE_LIBCEC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 project(moonlight-embedded C)
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 2.8.11)
 SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 include(${CMAKE_ROOT}/Modules/GNUInstallDirs.cmake)
 

--- a/cmake/use_c99.cmake
+++ b/cmake/use_c99.cmake
@@ -1,0 +1,11 @@
+# compatibility wrapper for CMAKE_C_STANDARD feature, for cmake versions older than 3.1
+# copied from http://stackoverflow.com/a/30564223
+macro(use_c99 target)
+  if (CMAKE_VERSION VERSION_LESS "3.1")
+    if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+    endif ()
+  else ()
+    set_property(TARGET target PROPERTY C_STANDARD 99)
+  endif ()
+endmacro(use_c99)

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: extra
 Maintainer: Iwan Timmer <irtimmer@gmail.com>
 Build-Depends:
  debhelper (>= 8.0.0),
- cmake,
+ cmake (>= 2.8.11),
  libopus-dev,
  libexpat1-dev,
  libasound2-dev,

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,33 @@ Source: moonlight-embedded
 Section: games
 Priority: extra
 Maintainer: Iwan Timmer <irtimmer@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), cmake, libopus-dev, libexpat1-dev, libasound2-dev, libudev-dev, libavahi-client-dev, libcurl4-openssl-dev, libevdev-dev, libraspberrypi-dev | rbp-userland-dev-osmc
+Build-Depends:
+ debhelper (>= 8.0.0),
+ cmake,
+ libopus-dev,
+ libexpat1-dev,
+ libasound2-dev,
+ libudev-dev,
+ libavahi-client-dev,
+ libcurl4-openssl-dev,
+ libevdev-dev,
+ libraspberrypi-dev | rbp-userland-dev-osmc
 Standards-Version: 3.9.3
 Homepage: https://github.com/irtimmer/moonlight-embedded
 
 Package: moonlight-embedded
 Architecture: armhf
-Depends: libopus0, libexpat1, libssl1.0.0, libasound2, libudev0, libavahi-client3, libcurl3, libevdev2, libraspberrypi0 | rbp-userland-osmc, ${shlibs:Depends}, ${misc:Depends}
+Depends:
+ libopus0,
+ libexpat1,
+ libssl1.0.0,
+ libasound2,
+ libudev0,
+ libavahi-client3,
+ libcurl3,
+ libevdev2,
+ libraspberrypi0 | rbp-userland-osmc,
+ ${shlibs:Depends}, ${misc:Depends}
 Recommends: alsa-base
 Suggests: alsa-utils
 Description: GameStream client for Linux

--- a/debian/patches/install.patch
+++ b/debian/patches/install.patch
@@ -1,15 +1,6 @@
 Compile using older version (2.8) of CMake
-Index: moonlight-embedded/CMakeLists.txt
-===================================================================
---- moonlight-embedded.orig/CMakeLists.txt	2015-08-14 14:05:22.000000000 +0000
-+++ moonlight-embedded/CMakeLists.txt	2015-08-14 14:06:06.000000000 +0000
-@@ -1,5 +1,5 @@
- project(moonlight-embedded C)
--cmake_minimum_required(VERSION 3.1)
-+cmake_minimum_required(VERSION 2.8)
- SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
- include(${CMAKE_ROOT}/Modules/GNUInstallDirs.cmake)
- 
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
 @@ -53,11 +53,11 @@
  
  add_executable(moonlight ${SRC_LIST})
@@ -55,10 +46,8 @@ Index: moonlight-embedded/CMakeLists.txt
  target_link_libraries(moonlight ${EVDEV_LIBRARIES} ${ALSA_LIBRARY} ${OPUS_LIBRARY} ${UDEV_LIBRARIES} ${CMAKE_DL_LIBS})
  
  add_subdirectory(docs)
-Index: moonlight-embedded/libgamestream/CMakeLists.txt
-===================================================================
---- moonlight-embedded.orig/libgamestream/CMakeLists.txt	2015-08-14 14:05:22.000000000 +0000
-+++ moonlight-embedded/libgamestream/CMakeLists.txt	2015-08-14 14:10:39.000000000 +0000
+--- a/libgamestream/CMakeLists.txt
++++ b/libgamestream/CMakeLists.txt
 @@ -14,13 +14,13 @@
  add_library(moonlight-common SHARED ${MOONLIGHT_COMMON_SRC_LIST})
  

--- a/debian/patches/install.patch
+++ b/debian/patches/install.patch
@@ -1,12 +1,7 @@
 Compile using older version (2.8) of CMake
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -53,11 +53,11 @@
- 
- add_executable(moonlight ${SRC_LIST})
- target_link_libraries(moonlight gamestream)
--set_property(TARGET moonlight PROPERTY C_STANDARD 99)
-+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+@@ -57,7 +57,7 @@
  
  if (CEC_FOUND AND CEC_VERSION_COMPATIBLE)
    list(APPEND MOONLIGHT_DEFINITIONS HAVE_LIBCEC)
@@ -48,14 +43,7 @@ Compile using older version (2.8) of CMake
  add_subdirectory(docs)
 --- a/libgamestream/CMakeLists.txt
 +++ b/libgamestream/CMakeLists.txt
-@@ -14,13 +14,13 @@
- add_library(moonlight-common SHARED ${MOONLIGHT_COMMON_SRC_LIST})
- 
- add_library(gamestream SHARED ${GAMESTREAM_SRC_LIST})
--set_property(TARGET gamestream PROPERTY C_STANDARD 99)
-+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
- target_link_libraries(gamestream moonlight-common)
- 
+@@ -20,7 +20,7 @@
  set_target_properties(gamestream PROPERTIES SOVERSION 0 VERSION ${MOONLIGHT_VERSION})
  set_target_properties(moonlight-common PROPERTIES SOVERSION 0 VERSION ${MOONLIGHT_VERSION})
  

--- a/libgamestream/CMakeLists.txt
+++ b/libgamestream/CMakeLists.txt
@@ -14,7 +14,7 @@ aux_source_directory(../third_party/moonlight-common-c/limelight-common/OpenAES 
 add_library(moonlight-common SHARED ${MOONLIGHT_COMMON_SRC_LIST})
 
 add_library(gamestream SHARED ${GAMESTREAM_SRC_LIST})
-set_property(TARGET gamestream PROPERTY C_STANDARD 99)
+use_c99(gamestream)
 target_link_libraries(gamestream moonlight-common)
 
 set_target_properties(gamestream PROPERTIES SOVERSION 0 VERSION ${MOONLIGHT_VERSION})


### PR DESCRIPTION
This set of patches adds an explicit dependency on cmake-2.8.11 for debian wheezy users.
I noticed the install.patch file was doing a lot of such compatibiltiy work, so I made it  a little smaller and more readable.

TODO: Whats now left in install.patch is not needed at all, for compiling with cmake 2.8.11. I dont however know if it has any other sideeffects.