### PR TITLE
fix reading from config file, so the argument may contain whitespaces

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -208,7 +208,7 @@ bool config_file_parse(char* filename, PCONFIGURATION config) {
 
   while (getline(&line, &len, fd) != -1) {
     char *key = NULL, *value = NULL;
-    if (sscanf(line, "%ms = %ms", &key, &value) == 2) {
+    if (sscanf(line, "%ms = %m[^\n]", &key, &value) == 2) {
       if (strcmp(key, "address") == 0) {
         config->address = value;
       } else if (strcmp(key, "sops") == 0) {


### PR DESCRIPTION
If you want to stream a different app than Steam by using the config file, then there are only apps allowed which names are only one word.
For example if you use "app = Game" then it's fine.
If you want to play "Game 2", then the 2 is ignored due to %s in scanf ignores whitespaces.
By using %[^\n] everything is read until a newline appears.
Also useful if you use a mapping file which has whitespaces in it (e.g "Sony Dualshock.map")