### PR TITLE
delete "config_file_parse" from main.c as it is already called in "config_parse"

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -188,10 +188,6 @@ int main(int argc, char* argv[]) {
     }
   }
   
-  char host_config_file[128];
-  sprintf(host_config_file, "hosts/%s.conf", config.address);
-  config_file_parse(host_config_file, &config);
-
   SERVER_DATA server;
   server.address = config.address;
   int ret;


### PR DESCRIPTION
config_file_parse is already called in config_parse, so it would be called twice.
Also they are high likely read from 2 different config-files.