### PR TITLE
Fix overrun of input buffers with large frames

### DIFF
--- a/src/video/pi.c
+++ b/src/video/pi.c
@@ -39,6 +39,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <ilclient.h>
 #include <bcm_host.h>
 
+#define MAX_DECODE_UNIT_SIZE 262144
+
 static TUNNEL_T tunnel[2];
 static COMPONENT_T *list[3];
 static ILCLIENT_T *client;
@@ -58,8 +60,6 @@ static void decoder_renderer_setup(int width, int height, int redrawRate, void* 
   OMX_VIDEO_PARAM_PORTFORMATTYPE format;
   OMX_TIME_CONFIG_CLOCKSTATETYPE cstate;
   COMPONENT_T *clock = NULL;
-  unsigned int data_len = 0;
-  int packet_size = 80<<10;
 
   memset(list, 0, sizeof(list));
   memset(tunnel, 0, sizeof(tunnel));
@@ -109,8 +109,27 @@ static void decoder_renderer_setup(int width, int height, int redrawRate, void* 
   unit.eUnitType = OMX_DataUnitCodedPicture;
   unit.eEncapsulationType = OMX_DataEncapsulationElementaryStream;
 
-  if(OMX_SetParameter(ILC_GET_HANDLE(video_decode), OMX_IndexParamVideoPortFormat, &format) == OMX_ErrorNone &&
-     OMX_SetParameter(ILC_GET_HANDLE(video_decode), OMX_IndexParamBrcmDataUnit, &unit) == OMX_ErrorNone &&
+  if(OMX_SetParameter(ILC_GET_HANDLE(video_decode), OMX_IndexParamVideoPortFormat, &format) != OMX_ErrorNone ||
+     OMX_SetParameter(ILC_GET_HANDLE(video_decode), OMX_IndexParamBrcmDataUnit, &unit) != OMX_ErrorNone) {
+    fprintf(stderr, "Failed to set video parameters\n");
+    exit(EXIT_FAILURE);
+  }
+
+  OMX_PARAM_PORTDEFINITIONTYPE port;
+
+  memset(&port, 0, sizeof(OMX_PARAM_PORTDEFINITIONTYPE));
+  port.nSize = sizeof(OMX_PARAM_PORTDEFINITIONTYPE);
+  port.nVersion.nVersion = OMX_VERSION;
+  port.nPortIndex = 130;
+  if(OMX_GetParameter(ILC_GET_HANDLE(video_decode), OMX_IndexParamPortDefinition, &port) != OMX_ErrorNone) {
+    fprintf(stderr, "Failed to get decoder port definition\n");
+    exit(EXIT_FAILURE);
+  }
+
+  // Increase the buffer size to fit the largest possible frame
+  port.nBufferSize = MAX_DECODE_UNIT_SIZE;
+
+  if(OMX_SetParameter(ILC_GET_HANDLE(video_decode), OMX_IndexParamPortDefinition, &port) == OMX_ErrorNone &&
      ilclient_enable_port_buffers(video_decode, 130, NULL, NULL, NULL) == 0) {
 
     port_settings_changed = 0;


### PR DESCRIPTION
The default ~80K isn't large enough for all frames, particularly 1080p at a high bitrate. The failure typically happens on the next IDR frame with a complex enough scene to go over the max size. Now we're asking for 256K buffers which should be enough for anything we can get from the PC.

See issue #198 