### PR TITLE
Flush stdout after prompting for user input when mapping gamepad

### DIFF
--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -433,6 +433,7 @@ void evdev_create(const char* device, char* mapFile) {
 
 static void evdev_map_key(char* keyName, short* key) {
   printf("Press %s\n", keyName);
+  fflush(stdout)
   currentKey = key;
   currentAbs = NULL;
   *key = -1;
@@ -444,6 +445,7 @@ static void evdev_map_key(char* keyName, short* key) {
 
 static void evdev_map_abs(char* keyName, short* abs, bool* reverse) {
   printf("Move %s\n", keyName);
+  fflush(stdout)
   currentKey = NULL;
   currentAbs = abs;
   currentReverse = reverse;
@@ -456,6 +458,7 @@ static void evdev_map_abs(char* keyName, short* abs, bool* reverse) {
 
 static void evdev_map_abskey(char* keyName, short* key, short* abs, bool* reverse) {
   printf("Press %s\n", keyName);
+  fflush(stdout)
   currentKey = key;
   currentAbs = abs;
   currentReverse = reverse;


### PR DESCRIPTION
Flush `stdout` after prompting for user input to allow parsing the prompt line by line in scripts. (Don't know if this is the best way to do it, but I've tried it in python and it does the trick)