### PR TITLE
Fix pairing on v2.1.3

### DIFF
--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -379,7 +379,7 @@ int gs_pair(PSERVER_DATA server, char* pin) {
   char challenge_response[16 + 256 + 16];
   char challenge_response_hash[32];
   char challenge_response_hash_enc[32];
-  char challenge_response_hex[33];
+  char challenge_response_hex[65];
   memcpy(challenge_response, challenge_response_data + 20, 16);
   memcpy(challenge_response + 16, cert->signature->data, 256);
   memcpy(challenge_response + 16 + 256, client_secret_data, 16);


### PR DESCRIPTION
There was a latent stack corruption bug that happened when pairing. It wasn't visible until the UUID stuff got added. As a result, the UUID gets appended to the challenge response output, breaking it and causing pairing to fail every time.

This should fix #295 

Since the current release can't pair at all (on at least the Jessie build), I'd suggest that you make another build after this fix.