### PR TITLE
GFE Beta 2.11 support

### DIFF
--- a/libgamestream/CMakeLists.txt
+++ b/libgamestream/CMakeLists.txt
@@ -9,10 +9,13 @@ pkg_check_modules(AVAHI REQUIRED avahi-client)
 aux_source_directory(./ GAMESTREAM_SRC_LIST)
 aux_source_directory(../third_party/h264bitstream GAMESTREAM_SRC_LIST)
 
+aux_source_directory(../third_party/moonlight-common-c/enet MOONLIGHT_COMMON_SRC_LIST)
 aux_source_directory(../third_party/moonlight-common-c/limelight-common MOONLIGHT_COMMON_SRC_LIST)
 aux_source_directory(../third_party/moonlight-common-c/limelight-common/OpenAES MOONLIGHT_COMMON_SRC_LIST)
 
 add_library(moonlight-common SHARED ${MOONLIGHT_COMMON_SRC_LIST})
+target_include_directories(moonlight-common PRIVATE ../third_party/moonlight-common-c/enet/include)
+target_compile_definitions(moonlight-common PRIVATE -DHAS_SOCKLEN_T=1)
 
 add_library(gamestream SHARED ${GAMESTREAM_SRC_LIST})
 set_property(TARGET gamestream PROPERTY C_STANDARD 99)

--- a/src/video/fake.c
+++ b/src/video/fake.c
@@ -24,7 +24,7 @@
 static FILE* fd;
 static const char* fileName = "fake.h264";
 
-void decoder_renderer_setup(int width, int height, int redrawRate, void* context, int drFlags) {
+void decoder_renderer_setup(int videoFormat, int width, int height, int redrawRate, void* context, int drFlags) {
   fd = fopen(fileName, "w");
 }
 

--- a/src/video/imx.c
+++ b/src/video/imx.c
@@ -83,7 +83,7 @@ bool video_imx_init() {
   return vpu_Init(NULL) == RETCODE_SUCCESS;
 }
 
-static void decoder_renderer_setup(int width, int height, int redrawRate, void* context, int drFlags) {
+static void decoder_renderer_setup(int videoFormat, int width, int height, int redrawRate, void* context, int drFlags) {
   struct mxcfb_gbl_alpha alpha;
 
   dbuf.type = V4L2_BUF_TYPE_VIDEO_OUTPUT;

--- a/src/video/pi.c
+++ b/src/video/pi.c
@@ -53,7 +53,7 @@ static unsigned char *dest;
 static int port_settings_changed;
 static int first_packet;
 
-static void decoder_renderer_setup(int width, int height, int redrawRate, void* context, int drFlags) {
+static void decoder_renderer_setup(int videoFormat, int width, int height, int redrawRate, void* context, int drFlags) {
   bcm_host_init();
   gs_sps_init(width, height);
 

--- a/src/video/sdl.c
+++ b/src/video/sdl.c
@@ -32,7 +32,7 @@
 
 static char* ffmpeg_buffer;
 
-static void sdl_setup(int width, int height, int redrawRate, void* context, int drFlags) {
+static void sdl_setup(int videoFormat, int width, int height, int redrawRate, void* context, int drFlags) {
   int avc_flags = SLICE_THREADING;
   if (ffmpeg_init(width, height, avc_flags, 2) < 0) {
     fprintf(stderr, "Couldn't initialize video decoding\n");


### PR DESCRIPTION
This PR adds support for GFE Beta 2.11 (and likely future production versions of GFE). They removed the TCP support that we were using for control and input streams, so we've had to move to the ENet library.

You might need to do a recursive submodule update to be able to build.