### PR TITLE
Fix for pairing and streaming on Gen 7 servers (current production GFE)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ else()
   set(SOFTWARE_FOUND FALSE)
 endif()
 
-SET(MOONLIGHT_COMMON_INCLUDE_DIR ./third_party/moonlight-common-c)
+SET(MOONLIGHT_COMMON_INCLUDE_DIR ./third_party/moonlight-common-c/src)
 SET(GAMESTREAM_INCLUDE_DIR ./libgamestream)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/libgamestream/CMakeLists.txt
+++ b/libgamestream/CMakeLists.txt
@@ -10,8 +10,7 @@ pkg_check_modules(ENET REQUIRED libenet)
 aux_source_directory(./ GAMESTREAM_SRC_LIST)
 aux_source_directory(../third_party/h264bitstream GAMESTREAM_SRC_LIST)
 
-aux_source_directory(../third_party/moonlight-common-c/limelight-common MOONLIGHT_COMMON_SRC_LIST)
-aux_source_directory(../third_party/moonlight-common-c/limelight-common/OpenAES MOONLIGHT_COMMON_SRC_LIST)
+aux_source_directory(../third_party/moonlight-common-c/src MOONLIGHT_COMMON_SRC_LIST)
 
 add_library(moonlight-common SHARED ${MOONLIGHT_COMMON_SRC_LIST})
 
@@ -22,7 +21,7 @@ target_link_libraries(gamestream moonlight-common)
 set_target_properties(gamestream PROPERTIES SOVERSION 0 VERSION ${MOONLIGHT_VERSION})
 set_target_properties(moonlight-common PROPERTIES SOVERSION 0 VERSION ${MOONLIGHT_VERSION})
 
-target_include_directories(gamestream PRIVATE ../third_party/moonlight-common-c ../third_party/h264bitstream ${AVAHI_INCLUDE_DIRS} ${LIBUUID_INCLUDE_DIRS})
+target_include_directories(gamestream PRIVATE ../third_party/moonlight-common-c/src ../third_party/h264bitstream ${AVAHI_INCLUDE_DIRS} ${LIBUUID_INCLUDE_DIRS})
 target_include_directories(moonlight-common PRIVATE  ${ENET_INCLUDE_DIRS})
 target_link_libraries(gamestream ${CURL_LIBRARIES} ${OPENSSL_LIBRARIES} ${EXPAT_LIBRARIES} ${AVAHI_LIBRARIES} ${LIBUUID_LIBRARIES})
 target_link_libraries(moonlight-common ${ENET_LIBRARIES})

--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -23,7 +23,7 @@
 #include "client.h"
 #include "errors.h"
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <sys/stat.h>
 #include <stdbool.h>

--- a/libgamestream/client.h
+++ b/libgamestream/client.h
@@ -21,7 +21,7 @@
 
 #include "xml.h"
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <stdbool.h>
 

--- a/libgamestream/sps.h
+++ b/libgamestream/sps.h
@@ -17,7 +17,7 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #define GS_SPS_BITSTREAM_FIXUP 0x01
 #define GS_SPS_BASELINE_HACK 0x02

--- a/src/audio.h
+++ b/src/audio.h
@@ -19,7 +19,7 @@
 
 #include <stdbool.h>
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 extern const char* audio_device;
 

--- a/src/config.h
+++ b/src/config.h
@@ -17,7 +17,7 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <stdbool.h>
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -17,6 +17,6 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 extern CONNECTION_LISTENER_CALLBACKS connection_callbacks;

--- a/src/input/cec.c
+++ b/src/input/cec.c
@@ -19,7 +19,7 @@
 
 #ifdef HAVE_LIBCEC
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <ceccloader.h>
 

--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -24,7 +24,7 @@
 #include "mapping.h"
 
 #include "libevdev/libevdev.h"
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <libudev.h>
 #include <stdio.h>

--- a/src/input/sdlinput.c
+++ b/src/input/sdlinput.c
@@ -22,7 +22,7 @@
 #include "sdlinput.h"
 #include "../sdl.h"
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #define ACTION_MODIFIERS (MODIFIER_SHIFT|MODIFIER_ALT|MODIFIER_CTRL)
 #define QUIT_KEY SDLK_q

--- a/src/main.c
+++ b/src/main.c
@@ -33,7 +33,7 @@
 #include "input/cec.h"
 #include "input/sdlinput.h"
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/platform.h
+++ b/src/platform.h
@@ -17,7 +17,7 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <dlfcn.h>
 #include <stdlib.h>

--- a/src/sdl.c
+++ b/src/sdl.c
@@ -22,7 +22,7 @@
 #include "sdl.h"
 #include "input/sdlinput.h"
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 static bool done;
 static int fullscreen_flags;

--- a/src/video/aml.c
+++ b/src/video/aml.c
@@ -18,7 +18,7 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <stdio.h>
 #include <stdbool.h>

--- a/src/video/fake.c
+++ b/src/video/fake.c
@@ -17,7 +17,7 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <stdio.h>
 

--- a/src/video/ffmpeg.c
+++ b/src/video/ffmpeg.c
@@ -23,7 +23,7 @@
 #include "ffmpeg_vdpau.h"
 #endif
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <stdlib.h>
 #include <libswscale/swscale.h>

--- a/src/video/imx.c
+++ b/src/video/imx.c
@@ -17,7 +17,7 @@
  * along with Moonlight; if not, see <http://www.gnu.org/licenses/>.
  */
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/video/pi.c
+++ b/src/video/pi.c
@@ -30,7 +30,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "sps.h"
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/video/sdl.c
+++ b/src/video/sdl.c
@@ -21,7 +21,7 @@
 #include "../sdl.h"
 #include "ffmpeg.h"
 
-#include "limelight-common/Limelight.h"
+#include <Limelight.h>
 
 #include <SDL.h>
 #include <SDL_thread.h>


### PR DESCRIPTION
First, this PR fixes build issues related to the new code layout of the moonlight-common-c repo. If you want a different solution, you can avoid taking that commit. Your moonlight-common-c repo will need to be merged with upstream master to get the final changes required for Gen 7 to work.

Second, this PR fixes several bugs in the client code of libgamestream. 
- Streaming not working due to looking for "cancel" instead of "gamesession" when starting an app
- Unable to get serverinfo before pairing which broke pairing on Gen 7 servers since we didn't know we were pairing with a Gen 7 server. This also meant the code to tell the user that they couldn't pair because they were in game also didn't work.
- The rikeyid value sent in the launch request didn't match the one passed to common-c which isn't a major problem on older servers (it only causes the first input packet to be dropped) but causes total failure of input with GCM encryption used on Gen 7 and above.

**Purpose**
Bring full streaming support for Gen 7 servers