### PR TITLE
Fix integer overflow in analog stick deadzone calculation

### DIFF
--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -106,9 +106,9 @@ static short evdev_convert_value(struct input_event *ev, struct input_device *de
   else if (ev->value < parms->min)
     return reverse?SHRT_MAX:SHRT_MIN;
   else if (reverse)
-    return (parms->max - (ev->value<parms->avg?parms->flat*2:0) - ev->value) * (SHRT_MAX-SHRT_MIN) / (parms->max-parms->min-parms->flat*2) + SHRT_MIN;
+    return (long long)(parms->max - (ev->value<parms->avg?parms->flat*2:0) - ev->value) * (SHRT_MAX-SHRT_MIN) / (parms->max-parms->min-parms->flat*2) + SHRT_MIN;
   else
-    return (ev->value - (ev->value>parms->avg?parms->flat*2:0) - parms->min) * (SHRT_MAX-SHRT_MIN) / (parms->max-parms->min-parms->flat*2) + SHRT_MIN;
+    return (long long)(ev->value - (ev->value>parms->avg?parms->flat*2:0) - parms->min) * (SHRT_MAX-SHRT_MIN) / (parms->max-parms->min-parms->flat*2) + SHRT_MIN;
 }
 
 static char evdev_convert_value_byte(struct input_event *ev, struct input_device *dev, struct input_abs_parms *parms) {


### PR DESCRIPTION
There's an integer overflow in the deadzone calculation for the analog sticks that causes them to act very strange with some controllers of mine, because an intermediate calculation overflows the 32-bit integer type. This manifests as skew toward negative values and being unable to reach values > ~28000 in the positive direction. Casting one of the multiplicands to a 64-bit integer fixes the overflow.

For example:
Min = -32768
Max = 32767
Avg = 0
Flat = 4096

In this calculation: (ev->value - (ev->value>parms->avg?parms->flat*2:0) - parms->min) * (SHRT_MAX-SHRT_MIN)

At value 8191, we get
32767 * 65536 = 2147418112
At value 8192, we get:
32768 * 65536 = -2147483648
