### PR TITLE
Fix compile warning

### DIFF
--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -337,7 +337,7 @@ static int sign_it(const char *msg, size_t mlen, unsigned char **sig, size_t *sl
   return result;
 }
 
-static bool verifySignature(const char *data, int dataLength, const char *signature, int signatureLength, const char *cert) {
+static bool verifySignature(const char *data, int dataLength, char *signature, int signatureLength, const char *cert) {
     X509* x509;
     BIO* bio = BIO_new(BIO_s_mem());
     BIO_puts(bio, cert);


### PR DESCRIPTION
**Description**
During normal compile, the following warning comes up.
```
/home/pi/moonlight-embedded/libgamestream/client.c: In function âverifySignatureâ:
/home/pi/moonlight-embedded/libgamestream/client.c:357:47: warning: passing argument 2 of âEVP_DigestVerifyFinalâ discards âconstâ qualifier from pointer target type
     int result = EVP_DigestVerifyFinal(mdctx, signature, signatureLength);
                                               ^
In file included from /usr/include/openssl/x509.h:73:0,
                 from /usr/include/openssl/x509v3.h:62,
                 from /home/pi/moonlight-embedded/libgamestream/mkcert.h:21,
                 from /home/pi/moonlight-embedded/libgamestream/client.c:22:
/usr/include/openssl/evp.h:622:5: note: expected âunsigned char *â but argument is of type âconst char *â
 int EVP_DigestVerifyFinal(EVP_MD_CTX *ctx,
     ^
```
**Purpose**
This fixes that warning.  Compiler drops the const qualifier anyway.
