### PR TITLE
Enabled Keypad (/*-+. Enter) and PrintScreen

### DIFF
--- a/src/input/keyboard.h
+++ b/src/input/keyboard.h
@@ -73,7 +73,7 @@ static const short keyCodes[] = {
   0xBE, //VK_DOT
   0xBF, //VK_SLASH
   0x10, //VK_SHIFT Right shift
-  0, //VK_KPASTERISK
+  0x6A, //VK_KPASTERISK
   0x12, //VK_ALT Left alt
   0x20, //VK_SPACE
   0x14, //VK_CAPS_LOCK
@@ -92,16 +92,16 @@ static const short keyCodes[] = {
   0x67, //VK_NUMPAD7
   0x68, //VK_NUMPAD8
   0x69, //VK_NUMPAD9
-  0, //VK_NUMPAD_MINUS
+  0x6D, //VK_NUMPAD_MINUS
   0x64, //VK_NUMPAD4
   0x65, //VK_NUMPAD5
   0x66, //VK_NUMPAD6
-  0, //VK_NUMPADPLUS
+  0x6B, //VK_NUMPADPLUS
   0x61, //VK_NUMPAD1
   0x62, //VK_NUMPAD2
   0x63, //VK_NUMPAD3
   0x60, //VK_NUMPAD0
-  0, //KeyEvent.VK_NUMPADDOT
+  0x6E, //KeyEvent.VK_NUMPADDOT
   0,
   0, //KeyEvent.VK_ZENKAKUHANKAKU
   0, //KeyEvent.VK_102ND
@@ -114,10 +114,10 @@ static const short keyCodes[] = {
   0, //VK_KATAKANAHIRAGANA
   0, //VK_MUHENKAN
   0, //VK_KPJPCOMMA
-  0, //VK_KPENTER
+  0x0D, //VK_KPENTER
   0x11, //VK_CONTROL Right ctrl
-  0, //VK_KPSLASH
-  0, //VK_SYSRQ
+  0x6F, //VK_KPSLASH
+  0x2C, //VK_SYSRQ
   0x12, //VK_ALT Right alt
   0, //KeyEvent.VK_LINEFEED
   0x24, //VK_HOME


### PR DESCRIPTION
**Description**
Modified the keyboard.h file:
Enabled the keypad function keys (/), (*), (-), (+), (.) and ENTER.
Enabled the print screen button.
**Purpose**
To have a fully functional keyboard while using Moonlight. 