### PR TITLE
Fix on the return value test of IOGetVirtMem for imx platform

### DIFF
--- a/src/video/imx.c
+++ b/src/video/imx.c
@@ -116,7 +116,7 @@ static void decoder_renderer_setup(int videoFormat, int width, int height, int r
     exit(EXIT_FAILURE);
   }
 
-  if (IOGetVirtMem(&mem_desc) <= 0) {
+  if (IOGetVirtMem(&mem_desc) == -1) {
     fprintf(stderr, "Can't get virtual memory address\n");
     exit(EXIT_FAILURE);
   }


### PR DESCRIPTION
**Description**

on imx platform, IOGetVirmMem() may return valid addresses above 2 Go for some linux configuration (3G/1G). In this case the test fails.

**Purpose**
This patch fixes the test by testing the return value against -1