### PR TITLE
Lower required OpenSSL version to 1.0.2

### DIFF
--- a/libgamestream/CMakeLists.txt
+++ b/libgamestream/CMakeLists.txt
@@ -1,7 +1,7 @@
 find_package(LibUUID REQUIRED)
 find_package(Threads REQUIRED)
 find_package(CURL REQUIRED)
-find_package(OpenSSL 1.1 REQUIRED)
+find_package(OpenSSL 1.0.2 REQUIRED)
 find_package(EXPAT REQUIRED)
 
 pkg_check_modules(AVAHI REQUIRED avahi-client)


### PR DESCRIPTION
All current OpenSSL APIs in use here are also available in OpenSSL 1.0.2, so reduce the version the required version to accept OpenSSL 1.0.2 too. If you have some other reason you want to stay OpenSSL 1.1+, that's fine.

Builds and runs fine on my OpenSUSE Tumbleweed box running `OpenSSL 1.0.2k-fips  26 Jan 2017`