### PR TITLE
added missing #ifdefs for HAVE_VAAPI & HAVE_VDPAU

### DIFF
--- a/src/video/x11.c
+++ b/src/video/x11.c
@@ -58,10 +58,14 @@ static int frame_handle(int pipefd) {
   if (frame) {
     if (ffmpeg_decoder == SOFTWARE)
       egl_draw(frame->data);
+    #ifdef HAVE_VAAPI 
     else if (ffmpeg_decoder == VAAPI)
       vaapi_queue(frame, window, display_width, display_height);
+    #endif  
+    #ifdef HAVE_VDPAU
     else if (ffmpeg_decoder == VDPAU)
       vdpau_queue(frame);
+    #endif 
   }
 
   return LOOP_OK;


### PR DESCRIPTION
**Description**
Managed to compile moonlight-embedded on OrangePI PC and it works with VDPAU acceleration out of the box with pre-compiled drivers on Armbian 5.30, the only issue I had with the source is that VAAPI acceleration is not available, but in x11.c file there is code that is missing the necessary #ifdefs to omit VAAPI or VDPAU functions.
 
**Purpose**
Fix compilation&linking when VAAPI or VDPAU acceleration is not available.