### PR TITLE
Fix L/R trigger activations not being sent without activating other buttons

### DIFF
--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -286,11 +286,13 @@ static bool evdev_handle_event(struct input_event *ev, struct input_device *dev)
           dev->buttonFlags |= gamepadCode;
         else
           dev->buttonFlags &= ~gamepadCode;
-      } else if (dev->map != NULL && index == dev->map->btn_lefttrigger)
+      } else if (dev->map != NULL && index == dev->map->btn_lefttrigger) {
         dev->leftTrigger = ev->value ? UCHAR_MAX : 0;
-      else if (dev->map != NULL && index == dev->map->btn_righttrigger)
+        gamepadModified = true;
+      } else if (dev->map != NULL && index == dev->map->btn_righttrigger) {
         dev->rightTrigger = ev->value ? UCHAR_MAX : 0;
-      else {
+        gamepadModified = true;
+      } else {
         if (dev->map != NULL)
           fprintf(stderr, "Unmapped button: %d\n", ev->code);
 


### PR DESCRIPTION
Fix for #550. If the L/R trigger buttons are activated by themselves without activating other buttons then no data is sent over the wire. This appears to be because the gamepadModified flag is not set in this case.

Change should also be propagated to other branches.