### PR TITLE
Add missing headers

### DIFF
--- a/src/video/ffmpeg.c
+++ b/src/video/ffmpeg.c
@@ -27,6 +27,7 @@
 #endif
 
 #include <Limelight.h>
+#include <libavcodec/avcodec.h>
 
 #include <stdlib.h>
 #include <pthread.h>

--- a/src/video/ffmpeg_vaapi.h
+++ b/src/video/ffmpeg_vaapi.h
@@ -18,6 +18,7 @@
  */
 
 #include <va/va.h>
+#include <X11/Xlib.h>
 
 int vaapi_init_lib();
 int vaapi_init(AVCodecContext* decoder_ctx);

--- a/src/video/x11.c
+++ b/src/video/x11.c
@@ -34,6 +34,8 @@
 #include <X11/Xutil.h>
 
 #include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <poll.h>


### PR DESCRIPTION
**Description**

This patch adds missing headers to resolve `-Wimplicit` warnings and compilation errors (at least, on amd64).

**Purpose**

```
In file included from /tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/ffmpeg.c:26:0:
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/ffmpeg_vaapi.h:24:38: error: unknown type name 'Window'
 void vaapi_queue(AVFrame* dec_frame, Window win, int width, int height);
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/ffmpeg.c: In function 'ffmpeg_get_frame':
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/ffmpeg.c:162:13: warning: implicit declaration of function 'avcodec_receive_frame' [-Wimplicit-function-declaration]
   int err = avcodec_receive_frame(decoder_ctx, dec_frames[next_frame]);
             ^~~~~~~~~~~~~~~~~~~~~
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/ffmpeg.c: In function 'ffmpeg_decode':
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/ffmpeg.c:189:9: warning: implicit declaration of function 'avcodec_send_packet' [-Wimplicit-function-declaration]
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c: In function 'x11_setup':
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:94:19: warning: implicit declaration of function 'malloc' [-Wimplicit-function-declaration]
   ffmpeg_buffer = malloc(DECODER_BUFFER_SIZE + FF_INPUT_BUFFER_PADDING_SIZE);
                   ^~~~~~
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:94:19: warning: incompatible implicit declaration of built-in function 'malloc'
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:94:19: note: include '<stdlib.h>' or provide a declaration of 'malloc'
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:96:5: warning: implicit declaration of function 'fprintf' [-Wimplicit-function-declaration]
     fprintf(stderr, "Not enough memory\n");
     ^~~~~~~
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:96:5: warning: incompatible implicit declaration of built-in function 'fprintf'
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:96:5: note: include '<stdio.h>' or provide a declaration of 'fprintf'
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:96:13: error: 'stderr' undeclared (first use in this function)
     fprintf(stderr, "Not enough memory\n");
             ^~~~~~
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:96:13: note: each undeclared identifier is reported only once for each function it appears in
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:101:5: warning: incompatible implicit declaration of built-in function 'fprintf'
     fprintf(stderr, "Error: failed to open X display.\n");
     ^~~~~~~
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:101:5: note: include '<stdio.h>' or provide a declaration of 'fprintf'
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:144:5: warning: incompatible implicit declaration of built-in function 'fprintf'
     fprintf(stderr, "Couldn't initialize video decoding\n");
     ^~~~~~~
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:144:5: note: include '<stdio.h>' or provide a declaration of 'fprintf'
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:157:5: warning: incompatible implicit declaration of built-in function 'fprintf'
     fprintf(stderr, "Can't create communication channel between threads\n");
     ^~~~~~~
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:157:5: note: include '<stdio.h>' or provide a declaration of 'fprintf'
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c: In function 'x11_submit_decode_unit':
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:186:7: warning: implicit declaration of function 'memcpy' [-Wimplicit-function-declaration]
       memcpy(ffmpeg_buffer+length, entry->data, entry->length);
       ^~~~~~
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:186:7: warning: incompatible implicit declaration of built-in function 'memcpy'
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:186:7: note: include '<string.h>' or provide a declaration of 'memcpy'
/tmp/nix-build-moonlight-embedded-2.4.3.drv-0/moonlight-embedded-v2.4.3-src/src/video/x11.c:193:7: warning: ignoring return value of 'write', declared with attribute warn_unused_result [-Wunused-result]
       write(pipefd[1], &frame, sizeof(void*));
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```