### PR TITLE
FindFreescale.cmake: fixed kernel headers include path

### DIFF
--- a/cmake/FindFreescale.cmake
+++ b/cmake/FindFreescale.cmake
@@ -7,7 +7,7 @@ mark_as_advanced(BROADCOM_INCLUDE_DIR)
 find_path(KERNEL_INCLUDE_DIR
   NAMES linux/mxc_v4l2.h
   DOC "Kernel include directory"
-  PATHS /lib/modules/${CMAKE_SYSTEM_VERSION}/build)
+  PATHS /lib/modules/${CMAKE_SYSTEM_VERSION}/build/include)
 mark_as_advanced(KERNEL_INCLUDE_DIR)
 
 find_library(VPU_LIBRARY


### PR DESCRIPTION
`/lib/modules/%kernel_version%/build/include` is valid location for 'linux/mxc_v4l2.h' header file. Tested on Udoobontu (based on ubuntu 14.04), Ubuntu 16.04, Archlinux.