### PR TITLE
evdev: limit unnecessary polls

### DIFF
--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -418,7 +418,7 @@ static void evdev_drain(void) {
 
 static int evdev_handle(int fd) {
   for (int i=0;i<numDevices;i++) {
-    if (devices[i].fd = fd) {
+    if (devices[i].fd == fd) {
       int rc;
       struct input_event ev;
       while ((rc = libevdev_next_event(devices[i].dev, LIBEVDEV_READ_FLAG_NORMAL, &ev)) >= 0) {


### PR DESCRIPTION
The previous code was probably a typo.
This patch doesn't bring any measurable
performance improvements, but still
prevents the fd from being corrupted.

Signed-off-by: Dariusz Stojaczyk <darek.stojaczyk@gmail.com>