### PR TITLE
FindAmlogic: don't depend on amadec and amavutils

### DIFF
--- a/cmake/FindAmlogic.cmake
+++ b/cmake/FindAmlogic.cmake
@@ -4,18 +4,6 @@ find_path(AMLOGIC_INCLUDE_DIR
   PATHS /usr/local/include/amcodec /usr/include/amcodec /usr/include/)
 mark_as_advanced(AMLOGIC_INCLUDE_DIR)
 
-find_library(AMAVUTILS_LIBRARY
-  NAMES libamavutils.so
-  DOC "Path to Amlogic Audio Video Utils Library"
-  PATHS /usr/lib/aml_libs /usr/local/lib /usr/lib)
-mark_as_advanced(AMAVUTILS_LIBRARY)
-
-find_library(AMADEC_LIBRARY
-  NAMES libamadec.so
-  DOC "Path to Amlogic Audio Decoder Library"
-  PATHS /usr/lib/aml_libs /usr/local/lib /usr/lib)
-mark_as_advanced(AMADEC_LIBRARY)
-
 find_library(AMCODEC_LIBRARY
   NAMES libamcodec.so
   DOC "Path to Amlogic Video Codec Library"
@@ -23,7 +11,7 @@ find_library(AMCODEC_LIBRARY
 mark_as_advanced(AMCODEC_LIBRARY)
 
 include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(Amlogic DEFAULT_MSG AMLOGIC_INCLUDE_DIR AMCODEC_LIBRARY AMADEC_LIBRARY AMAVUTILS_LIBRARY)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Amlogic DEFAULT_MSG AMLOGIC_INCLUDE_DIR AMCODEC_LIBRARY)
 
-set(AMLOGIC_LIBRARIES ${AMCODEC_LIBRARY} ${AMADEC_LIBRARY} ${AMAVUTILS_LIBRARY})
+set(AMLOGIC_LIBRARIES ${AMCODEC_LIBRARY})
 set(AMLOGIC_INCLUDE_DIRS ${AMLOGIC_INCLUDE_DIR})


### PR DESCRIPTION
**Description**
Moonlight only uses libamcodec, make it depend only on it.

**Purpose**
Recently we added a cleanup in LibreELEC to include only libamcodec, which is the only really needed library for hardware-accelerated video decoding. Missing libamadec and libamavutils broke compiling moonlight-embedded, which doesn't use them anyway. Removing these useless libraries from CMake fixes compilation.