### PR TITLE
Fix double mouse capture, add isc option for custom input handling

### DIFF
--- a/.directory
+++ b/.directory
@@ -1,0 +1,3 @@
+[Dolphin]
+Timestamp=2018,3,17,12,9,4
+Version=4

--- a/src/config.c
+++ b/src/config.c
@@ -45,6 +45,7 @@ static struct option long_options[] = {
   {"720", no_argument, NULL, 'a'},
   {"1080", no_argument, NULL, 'b'},
   {"4k", no_argument, NULL, '0'},
+  {"isc", required_argument, NULL, '1'},
   {"width", required_argument, NULL, 'c'},
   {"height", required_argument, NULL, 'd'},
   {"bitrate", required_argument, NULL, 'g'},
@@ -123,6 +124,9 @@ char* get_path(char* name, char* extra_data_dirs) {
 
 static void parse_argument(int c, char* value, PCONFIGURATION config) {
   switch (c) {
+  case '1':
+    config->isc = value;
+    break;
   case 'a':
     config->stream.width = 1280;
     config->stream.height = 720;
@@ -285,7 +289,8 @@ void config_save(char* filename, PCONFIGURATION config) {
     write_config_bool(fd, "sops", config->sops);
   if (config->localaudio)
     write_config_bool(fd, "localaudio", config->localaudio);
-
+  if (config->isc)
+      write_config_string(fd, "isc", config->isc);
   if (strcmp(config->app, "Steam") != 0)
     write_config_string(fd, "app", config->app);
 
@@ -316,6 +321,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->fullscreen = true;
   config->unsupported = false;
   config->codec = CODEC_UNSPECIFIED;
+  config->isc = NULL;
 
   config->inputsCount = 0;
   config->mapping = get_path("gamecontrollerdb.txt", getenv("XDG_DATA_DIRS"));

--- a/src/config.h
+++ b/src/config.h
@@ -35,6 +35,7 @@ typedef struct _CONFIGURATION {
   char* platform;
   char* audio_device;
   char* config_file;
+  char* isc;
   char key_dir[4096];
   bool sops;
   bool localaudio;

--- a/src/input/x11.c
+++ b/src/input/x11.c
@@ -32,6 +32,7 @@
 #include <stdbool.h>
 #include <stdlib.h>
 #include <poll.h>
+#include <string.h>
 
 #define MODIFIERS (MODIFIER_SHIFT|MODIFIER_ALT|MODIFIER_CTRL)
 
@@ -46,7 +47,6 @@ static int keyboard_modifiers;
 static const char data[1] = {0};
 static Cursor cursor;
 static bool grabbed = True;
-static release = false;
 
 static int x11_handler(int fd) {
   XEvent event;
@@ -62,9 +62,7 @@ static int x11_handler(int fd) {
         if ((keyboard_modifiers & MODIFIERS) == MODIFIERS && event.type == KeyRelease) {
           if (event.xkey.keycode == 0x18) {
             return LOOP_RETURN;
-          }
-          else if (strcmp(isc_global, "-1") == 0) {
-            release = true;
+          } else if (strcmp(isc_global, "-1") == 0) {
             grabbed = !grabbed;
             XDefineCursor(display, window, grabbed ? cursor : 0);
           }
@@ -94,8 +92,7 @@ static int x11_handler(int fd) {
         }
 
         short code = 0x80 << 8 | keyCodes[event.xkey.keycode - 8];
-        if (grabbed || release) LiSendKeyboardEvent(code, event.type == KeyPress ? KEY_ACTION_DOWN : KEY_ACTION_UP, keyboard_modifiers);
-        release = false;
+        if (grabbed || (modifier != 0 && event.type == KeyRelease && (code == -32750 || code == -32751 || code == -32752))) LiSendKeyboardEvent(code, event.type == KeyPress ? KEY_ACTION_DOWN : KEY_ACTION_UP, keyboard_modifiers);
       }
       break;
     case ButtonPress:

--- a/src/input/x11.c
+++ b/src/input/x11.c
@@ -46,6 +46,7 @@ static int keyboard_modifiers;
 static const char data[1] = {0};
 static Cursor cursor;
 static bool grabbed = True;
+static release = false;
 
 static int x11_handler(int fd) {
   XEvent event;
@@ -63,6 +64,7 @@ static int x11_handler(int fd) {
             return LOOP_RETURN;
           }
           else if (strcmp(isc_global, "-1") == 0) {
+            release = true;
             grabbed = !grabbed;
             XDefineCursor(display, window, grabbed ? cursor : 0);
           }
@@ -92,7 +94,8 @@ static int x11_handler(int fd) {
         }
 
         short code = 0x80 << 8 | keyCodes[event.xkey.keycode - 8];
-        if (grabbed) LiSendKeyboardEvent(code, event.type == KeyPress ? KEY_ACTION_DOWN : KEY_ACTION_UP, keyboard_modifiers);
+        if (grabbed || release) LiSendKeyboardEvent(code, event.type == KeyPress ? KEY_ACTION_DOWN : KEY_ACTION_UP, keyboard_modifiers);
+        release = false;
       }
       break;
     case ButtonPress:

--- a/src/loop.c
+++ b/src/loop.c
@@ -52,7 +52,6 @@ static int loop_sig_handler(int fd) {
 void loop_add_fd(int fd, FdHandler handler, int events) {
   int fdindex = numFds;
   numFds++;
-
   if (fds == NULL) {
     fds = malloc(sizeof(struct pollfd));
     fdHandlers = malloc(sizeof(FdHandler*));

--- a/src/util.h
+++ b/src/util.h
@@ -20,3 +20,4 @@
 #include <stdbool.h>
 
 int blank_fb(char *path, bool clear);
+extern char* isc_global;


### PR DESCRIPTION
Note: Changes here only apply to X11 platforms. Also, this is my _first_ ever time working with C code. And yes, I've read the contributing guidelines.

**Purpose**
Fix double mouse capture, fixes #637 . 
Add `-isc <file>` option. Allows for better handling of non-gamestream input passthrough mechanisms such as usbip or virtualhere (I'm using it for USB-passthrough with a VM). There's more information in the help.
Misc binding changes for better user experience.
**Description**
Double mouse capture: This was happening because the keyboard and mice both had mappings so it was passing it through like it would a game controller which overrided all the stuff in `input/X11.c`. Unfortunately the only fix I could come up with was to disable the `autoadd` for X11 which means that users will have to manually specify their controllers using `-input`.

isc: This works by disabling binding of mouse/keyboard during startup, overriding any mechanism of binding, and running a given script whenever the user clicks inside the window. There are possible security risks attached when using this option, so I've included a very through warning in the help. 

Misc binding changes: Mouse and keyboard will only register on gamestream host when they're captured. Left clicking on the window now captures. The reason for these changes is that originally, there would be two cursors and while moving the mouse over the moonlight window, it would also move the mouse of the GS host (which was in a different position, so there were 2 moving cursors) and when clicking to focus the window, the click would also register on the GS host which was really annoying because the cursors were in different places.

