### PR TITLE
hide cursor in left lower corner instead of delete it

### DIFF
--- a/src/video/rk.c
+++ b/src/video/rk.c
@@ -356,8 +356,8 @@ int rk_setup(int videoFormat, int width, int height, int redrawRate, void* conte
   }
   assert(plane_id);
 
-  // disable cursor
-  drmModeSetCursor(fd, crtc_id, 0, 0, 0);
+  // hide cursor by move in left lower corner
+  drmModeMoveCursor(fd, crtc_id, 0, crtc_height);
 
   // MPI SETUP
 


### PR DESCRIPTION
**Description**

It's easier on exit to recover the mouse pointer by hiding it in the left lower corner instead of deleting it

**Purpose**

Get upstream asap