### PR TITLE
replace malloc/strcpy pair with strdup to allocate correct size

### DIFF
--- a/libgamestream/xml.c
+++ b/libgamestream/xml.c
@@ -118,11 +118,8 @@ static void XMLCALL _xml_start_status_element(void *userData, const char *name, 
     for (int i = 0; atts[i]; i += 2) {
       if (strcmp("status_code", atts[i]) == 0)
         *status = atoi(atts[i + 1]);
-      else if (*status != STATUS_OK && strcmp("status_message", atts[i]) == 0) {
-        gs_error = malloc(strlen(atts[i + 1]));
-        if (gs_error)
-          strcpy((char*) gs_error, atts[i + 1]);
-      }
+      else if (*status != STATUS_OK && strcmp("status_message", atts[i]) == 0)
+        gs_error = strdup(atts[i + 1]);
     }
   }
 }


### PR DESCRIPTION
**Description**

The malloc for the string allocated one too few bytes for the full string plus the terminating null character (https://lgtm.com/rules/2162380047/). As recommended, I've replaced the `malloc`/`strcpy` pair with `strdup`.

This was found using LGTM.com, there are some other findings [here](https://lgtm.com/projects/g/irtimmer/moonlight-embedded/alerts/?mode=list) and you can [enable automated PR analysis](https://lgtm.com/projects/g/irtimmer/moonlight-embedded/ci/) to guard against new issues being introduced.

Full disclosure: I work for Semmle, the company behind LGTM.com.

**Purpose**

Fixes a crash if an error status is set by a gamestream server.