### PR TITLE
Add support for X1 and X2 mouse buttons

### DIFF
--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -246,6 +246,12 @@ static bool evdev_handle_event(struct input_event *ev, struct input_device *dev)
       case BTN_RIGHT:
         mouseCode = BUTTON_RIGHT;
         break;
+      case BTN_SIDE:
+        mouseCode = BUTTON_X1;
+        break;
+      case BTN_EXTRA:
+        mouseCode = BUTTON_X2;
+        break;
       default:
         gamepadModified = true;
         if (dev->map == NULL)

--- a/src/input/sdl.c
+++ b/src/input/sdl.c
@@ -96,6 +96,12 @@ int sdlinput_handle_event(SDL_Event* event) {
     case SDL_BUTTON_RIGHT:
       button = BUTTON_RIGHT;
       break;
+    case SDL_BUTTON_X1:
+      button = BUTTON_X1;
+      break;
+    case SDL_BUTTON_X2:
+      button = BUTTON_X2;
+      break;
     }
 
     if (button != 0)

--- a/src/input/x11.c
+++ b/src/input/x11.c
@@ -110,6 +110,12 @@ static int x11_handler(int fd) {
       case Button5:
         LiSendScrollEvent(-1);
         break;
+      case 8:
+        button = BUTTON_X1;
+        break;
+      case 9:
+        button = BUTTON_X2;
+        break;
       }
 
       if (button != 0)


### PR DESCRIPTION
**Description**
This PR adds support for the X1 and X2 mouse buttons (commonly known as Back and Forward) to all input backends.

**Purpose**
I recently confirmed these buttons now work in GFE 3.14.1 (maybe earlier too), so I added them to Limelight.h and implemented them in Moonlight PC and Moonlight Android.

**Before merging, pull my latest changes from moonlight-common-c upstream to get the definitions for BUTTON_X1 and BUTTON_X2**