### PR TITLE
Improve code consistency and readability

### DIFF
--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -93,7 +93,7 @@ static bool grabbingDevices;
 
 int evdev_gamepads = 0;
 
-#define QUIT_MODIFIERS (MODIFIER_SHIFT|MODIFIER_ALT|MODIFIER_CTRL)
+#define ACTION_MODIFIERS (MODIFIER_SHIFT|MODIFIER_ALT|MODIFIER_CTRL)
 #define QUIT_KEY KEY_Q
 #define QUIT_BUTTONS (PLAY_FLAG|BACK_FLAG|LB_FLAG|RB_FLAG)
 
@@ -224,7 +224,7 @@ static bool evdev_handle_event(struct input_event *ev, struct input_device *dev)
       }
 
       // Quit the stream if all the required quit keys are down
-      if ((dev->modifiers & QUIT_MODIFIERS) == QUIT_MODIFIERS &&
+      if ((dev->modifiers & ACTION_MODIFIERS) == ACTION_MODIFIERS &&
           ev->code == QUIT_KEY && ev->value != 0) {
         return false;
       }

--- a/src/input/x11.c
+++ b/src/input/x11.c
@@ -31,7 +31,7 @@
 #include <stdlib.h>
 #include <poll.h>
 
-#define MODIFIERS (MODIFIER_SHIFT|MODIFIER_ALT|MODIFIER_CTRL)
+#define ACTION_MODIFIERS (MODIFIER_SHIFT|MODIFIER_ALT|MODIFIER_CTRL)
 
 static Display *display;
 static Window window;
@@ -56,7 +56,7 @@ static int x11_handler(int fd) {
     case KeyPress:
     case KeyRelease:
       if (event.xkey.keycode >= 8 && event.xkey.keycode < (sizeof(keyCodes)/sizeof(keyCodes[0]) + 8)) {
-        if ((keyboard_modifiers & MODIFIERS) == MODIFIERS && event.type == KeyRelease) {
+        if ((keyboard_modifiers & ACTION_MODIFIERS) == ACTION_MODIFIERS && event.type == KeyRelease) {
           if (event.xkey.keycode == 0x18)
             return LOOP_RETURN;
           else {

--- a/src/input/x11.c
+++ b/src/input/x11.c
@@ -32,6 +32,7 @@
 #include <poll.h>
 
 #define ACTION_MODIFIERS (MODIFIER_SHIFT|MODIFIER_ALT|MODIFIER_CTRL)
+#define QUIT_KEY 0x18  /* KEY_Q */
 
 static Display *display;
 static Window window;
@@ -57,7 +58,7 @@ static int x11_handler(int fd) {
     case KeyRelease:
       if (event.xkey.keycode >= 8 && event.xkey.keycode < (sizeof(keyCodes)/sizeof(keyCodes[0]) + 8)) {
         if ((keyboard_modifiers & ACTION_MODIFIERS) == ACTION_MODIFIERS && event.type == KeyRelease) {
-          if (event.xkey.keycode == 0x18)
+          if (event.xkey.keycode == QUIT_KEY)
             return LOOP_RETURN;
           else {
             grabbed = !grabbed;


### PR DESCRIPTION
**Description**
This PR does not change any functionality, but it improves code consistency and readability.
Two main changes are proposed:
1. The action modifiers constants `QUIT_MODIFIERS` and `MODIFIERS` in `input/{evdev,x11}.c` respectively are renamed to `ACTION_MODIFIERS` as it is in `input/sdl.c`, so these are consistently named across all three input drivers.
2. A new `QUIT_KEY` constant is added to `input/x11.c` and used instead of the direct key code for readability. This constant name is also consistent across all three input drivers.

**Purpose**
Make the codebase more consistent, readable and clean, hence better to maintain and work with.
I plan to bring some new functionality and cleaning up the code helps to have less clutter in future.
I hope this can be merged soon. Thanks!