### PR TITLE
Add option for sending quit app request after quitting streaming session

### DIFF
--- a/docs/README.pod
+++ b/docs/README.pod
@@ -145,6 +145,10 @@ Select platform for audio and video output and input.
 
 Try streaming if GFE version or options are unsupported
 
+=item B<-quitappafter>
+
+Send quit app request to remote after quitting session
+
 =item B<-verbose>
 
 Enable verbose output

--- a/moonlight.conf
+++ b/moonlight.conf
@@ -40,6 +40,9 @@
 ## Play audio on host instead of streaming to client
 #localaudio = false
 
+## Send quit app request to remote after quitting session
+#quitappafter = false
+
 ## Select audio device to play sound on
 #audio = sysdefault
 

--- a/src/config.c
+++ b/src/config.c
@@ -65,6 +65,7 @@ static struct option long_options[] = {
   {"fps", required_argument, NULL, 'v'},
   {"codec", required_argument, NULL, 'x'},
   {"unsupported", no_argument, NULL, 'y'},
+  {"quitappafter", no_argument, NULL, '1'},
   {"verbose", no_argument, NULL, 'z'},
   {"debug", no_argument, NULL, 'Z'},
   {0, 0, 0, 0},
@@ -212,6 +213,9 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
   case 'y':
     config->unsupported = true;
     break;
+  case '1':
+    config->quitappafter = true;
+    break;
   case 'z':
     config->debug_level = 1;
     break;
@@ -249,6 +253,8 @@ bool config_file_parse(char* filename, PCONFIGURATION config) {
         config->sops = strcmp("true", value) == 0;
       } else if (strcmp(key, "localaudio") == 0) {
         config->localaudio = strcmp("true", value) == 0;
+      } else if (strcmp(key, "quitappafter") == 0) {
+        config->quitappafter = strcmp("true", value) == 0;
       } else {
         for (int i=0;long_options[i].name != NULL;i++) {
           if (strcmp(long_options[i].name, key) == 0) {
@@ -285,6 +291,8 @@ void config_save(char* filename, PCONFIGURATION config) {
     write_config_bool(fd, "sops", config->sops);
   if (config->localaudio)
     write_config_bool(fd, "localaudio", config->localaudio);
+  if (config->quitappafter)
+    write_config_bool(fd, "quitappafter", config->quitappafter);
 
   if (strcmp(config->app, "Steam") != 0)
     write_config_string(fd, "app", config->app);
@@ -315,6 +323,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->localaudio = false;
   config->fullscreen = true;
   config->unsupported = false;
+  config->quitappafter = false;
   config->codec = CODEC_UNSPECIFIED;
 
   config->inputsCount = 0;

--- a/src/config.h
+++ b/src/config.h
@@ -40,6 +40,7 @@ typedef struct _CONFIGURATION {
   bool localaudio;
   bool fullscreen;
   bool unsupported;
+  bool quitappafter;
   char* inputs[MAX_INPUTS];
   int inputsCount;
   enum codecs codec;

--- a/src/main.c
+++ b/src/main.c
@@ -135,6 +135,13 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, enum platform sys
   #endif
 
   LiStopConnection();
+
+  if (config->quitappafter) {
+    if (config->debug_level > 0)
+      printf("Sending app quit request ...\n");
+    gs_quit_app(server);
+  }
+
   platform_stop(system);
 }
 
@@ -174,6 +181,7 @@ static void help() {
   printf("\t-mapping <file>\t\tUse <file> as gamepad mappings configuration file\n");
   printf("\t-platform <system>\tSpecify system used for audio, video and input: pi/imx/aml/rk/x11/x11_vdpau/sdl/fake (default auto)\n");
   printf("\t-unsupported\t\tTry streaming if GFE version or options are unsupported\n");
+  printf("\t-quitappafter\t\tSend quit app request to remote after quitting session\n");
   #if defined(HAVE_SDL) || defined(HAVE_X11)
   printf("\n WM options (SDL and X11 only)\n\n");
   printf("\t-windowed\t\tDisplay screen in a window\n");


### PR DESCRIPTION
**Description**
Currently, when quitting a streaming session via key combo (gamepad or keyboard), Moonlight immediately closes the connection and exits, leaving the remote server in an unstable state because GFE doesn't free/close any audio/video resources on abrupt disconnection. One can return the server to normal by manually sending a quit app request from Moonlight after closing the session.

This has been reported numerous times in the past now:
https://github.com/irtimmer/moonlight-embedded/issues/721
https://github.com/irtimmer/moonlight-embedded/issues/576
https://github.com/irtimmer/moonlight-embedded/issues/652
https://retropie.org.uk/forum/post/170489
https://retropie.org.uk/forum/post/176216
https://forum.recalbox.com/topic/7895/moonlight-exit-game

In this PR, I'm adding a new option named `quitappafter` that allows Moonlight to automatically send a quit app request to the server before terminating the streaming session so GFE cleans gracefully. This is implemented in a very similar way to the same option found in Moonlight-QT:
https://github.com/moonlight-stream/moonlight-qt/blob/master/app/streaming/session.cpp#L580

Like in Moonlight-QT, the option is disabled by default (keeping current behaviour) and the user can either enable it via command-line option or in a configuration file.

This PR has been tested and working very well on my end.

**Purpose**
Allow moonlight to automatically send a quit app request to the remote server before terminating the streaming session on quit, so GFE also terminates gracefully and restores audio/video settings on server.

Fixes #721, Fixes #576, Fixes #652