### PR TITLE
Only grab input devices if they are keyboards

### DIFF
--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -55,6 +55,7 @@ struct input_abs_parms {
 
 struct input_device {
   struct libevdev *dev;
+  bool is_keyboard;
   struct mapping* map;
   int key_map[KEY_MAX];
   int abs_map[ABS_MAX];
@@ -527,6 +528,7 @@ void evdev_create(const char* device, struct mapping* mappings, bool verbose) {
   devices[dev].map = mappings;
   memset(&devices[dev].key_map, -2, sizeof(devices[dev].key_map));
   memset(&devices[dev].abs_map, -2, sizeof(devices[dev].abs_map));
+  devices[dev].is_keyboard = is_keyboard;
 
   int nbuttons = 0;
   for (int i = BTN_JOYSTICK; i < KEY_MAX; ++i) {
@@ -561,7 +563,7 @@ void evdev_create(const char* device, struct mapping* mappings, bool verbose) {
       fprintf(stderr, "Mapping for %s (%s) on %s is incorrect\n", name, str_guid, device);
   }
 
-  if (grabbingDevices) {
+  if (grabbingDevices && is_keyboard) {
     if (ioctl(fd, EVIOCGRAB, 1) < 0) {
       fprintf(stderr, "EVIOCGRAB failed with error %d\n", errno);
     }
@@ -688,7 +690,7 @@ void evdev_start() {
   // we're ready to take input events. Ctrl+C works up until
   // this point.
   for (int i = 0; i < numDevices; i++) {
-    if (ioctl(devices[i].fd, EVIOCGRAB, 1) < 0) {
+    if (devices[i].is_keyboard && ioctl(devices[i].fd, EVIOCGRAB, 1) < 0) {
       fprintf(stderr, "EVIOCGRAB failed with error %d\n", errno);
     }
   }


### PR DESCRIPTION
**Description**

The current evdev input implementation attempts to grab (EVIOCGRAB) every device it finds. This is required for the CTRL+C combo to not interrupt Moonlight when streaming. However, other devices that are not keyboards, i.e. gamepads, do not require this grabbing, and doing so prevent other external applications from using them concurrently. This situation can happen for example when monitoring the gamepad for activity with the purpose of turning it off as done in WIP work in RetroPie for DS3 controllers.

This PR makes the grabbing code to be more specific and only grab keyboard-type devices in `evdev_create()`. Furthermore, the `is_keyboard` boolean is promoted to the `input_device` struct so it can be used in `evdev_start()` as well. These are the only two places where EVIOCGRAB is issued.

Tested using a real keyobard, a DS3 controller and a simple button input device on a Raspberry Pi 3 B+.

**Purpose**

Prevent Moonlight from grabbing input devices that are not keyboards, allowing them to be used by other external applications concurrently.