### PR TITLE
Fix bugs found by compiler warnings

### DIFF
--- a/src/loop.c
+++ b/src/loop.c
@@ -76,14 +76,15 @@ void loop_remove_fd(int fd) {
   int fdindex;
   
   for (int i=0;i<numFds;i++) {
-    if (fds[i].fd = fd)
+    if (fds[i].fd == fd) {
       fdindex = i;
       break;
+    }
   }
   
   if (fdindex != numFds && numFds > 0) {
     memcpy(&fds[fdindex], &fds[numFds], sizeof(struct pollfd));
-    memcpy(&fdHandlers[fdindex], &fdHandlers[numFds], sizeof(FdHandler*));
+    memcpy(&fdHandlers[fdindex], &fdHandlers[numFds], sizeof(FdHandler));
   }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -95,7 +95,7 @@ static void stream(PSERVER_DATA server, PCONFIGURATION config, enum platform sys
   #ifdef HAVE_SDL
   gamepads += sdl_gamepads;
   #endif
-  int gamepad_mask;
+  int gamepad_mask = 0;
   for (int i = 0; i < gamepads && i < 4; i++)
     gamepad_mask = (gamepad_mask << 1) + 1;
 


### PR DESCRIPTION
**Description**
I was tracking down why we ended up with a bogus `gamepad_mask` value using `-Wall` and found several other bugs in the process.

**Purpose**
Fixes `gamepad_mask` to avoid falsely claiming to have a connected gamepad when one is not present.
Fixes `loop_remove_fd()` to work correctly for fds beyond the first in the array