### PR TITLE
Fix SPS length being 4 bytes short

### DIFF
--- a/libgamestream/sps.c
+++ b/libgamestream/sps.c
@@ -78,5 +78,5 @@ void gs_sps_fix(PLENTRY sps, int flags, uint8_t* out_buf, uint32_t* out_offset) 
   memcpy(out_buf+*out_offset, naluHeader, 4);
   *out_offset += 4;
 
-  *out_offset = write_nal_unit(h264_stream, out_buf+*out_offset, 128);
+  *out_offset += write_nal_unit(h264_stream, out_buf+*out_offset, 128);
 }


### PR DESCRIPTION
**Description**
My previous fix had a bug that I didn't detect during my testing that was causing the SPS to be too short when submitting to the decoder. This cuts off the section of the bitstream restrictions that fixes the high video latency (which was the whole point of the fixups in the first place).

As a result, the fixup for latency is broken and the Pi's video latency is high which makes many games unplayable.

Very sorry for missing this in my first PR :(

**Purpose**
Fix video latency on the Pi