### PR TITLE
video/rockchip: define READ_BUF_SIZE with a size of 0x00100000

### DIFF
--- a/src/video/rk.c
+++ b/src/video/rk.c
@@ -38,7 +38,7 @@
 
 #include <rockchip/rk_mpi.h>
 
-#define READ_BUF_SIZE (SZ_1M)
+#define READ_BUF_SIZE 0x00100000
 #define MAX_FRAMES 16
 #define RK_H264 7
 #define RK_H265 16777220


### PR DESCRIPTION
**Description**
If you use SZ_1M to define READ_BUF_SIZE you also need to include the sizes.h header file which is apparently missing. SZ_1M is defined as 0x00100000 so it should be replaced by this value.

https://github.com/irtimmer/moonlight-embedded/blob/master/src/video/rk.c#L41
https://cregit.linuxsources.org/code/4.14/include/linux/sizes.h.html

**Purpose**

Fix build for a Rockchip RK3399 project. Otherwise compilation fails because `SZ_1M` isn't declared.
