### PR TITLE
Use a SHA-256 signature for the client certificate to fix TLS on Buster

### DIFF
--- a/libgamestream/mkcert.c
+++ b/libgamestream/mkcert.c
@@ -147,7 +147,7 @@ int mkcert(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int years) {
     
     add_ext(x, NID_subject_key_identifier, "hash");
     
-    if (!X509_sign(x, pk, EVP_sha1())) {
+    if (!X509_sign(x, pk, EVP_sha256())) {
         goto err;
     }
     


### PR DESCRIPTION
**Description**
SHA-1 signed certificates have been phased out by CA and SSL client implementations. On Debian Buster, the default OpenSSL policy rejects SHA-1 certificates and prevents Moonlight from working.

**Purpose**
Stop generating new SHA-1 client certificates to fix pairing and streaming on Debian/Raspbian Buster with the default OpenSSL config.

Fixes #754 