### PR TITLE
Also grab mouse input devices (fixes #756)

### DIFF
--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -56,6 +56,7 @@ struct input_abs_parms {
 struct input_device {
   struct libevdev *dev;
   bool is_keyboard;
+  bool is_mouse;
   struct mapping* map;
   int key_map[KEY_MAX];
   int abs_map[ABS_MAX];
@@ -529,6 +530,7 @@ void evdev_create(const char* device, struct mapping* mappings, bool verbose) {
   memset(&devices[dev].key_map, -2, sizeof(devices[dev].key_map));
   memset(&devices[dev].abs_map, -2, sizeof(devices[dev].abs_map));
   devices[dev].is_keyboard = is_keyboard;
+  devices[dev].is_mouse = is_mouse;
 
   int nbuttons = 0;
   for (int i = BTN_JOYSTICK; i < KEY_MAX; ++i) {
@@ -563,7 +565,7 @@ void evdev_create(const char* device, struct mapping* mappings, bool verbose) {
       fprintf(stderr, "Mapping for %s (%s) on %s is incorrect\n", name, str_guid, device);
   }
 
-  if (grabbingDevices && is_keyboard) {
+  if (grabbingDevices && (is_keyboard || is_mouse)) {
     if (ioctl(fd, EVIOCGRAB, 1) < 0) {
       fprintf(stderr, "EVIOCGRAB failed with error %d\n", errno);
     }
@@ -690,7 +692,7 @@ void evdev_start() {
   // we're ready to take input events. Ctrl+C works up until
   // this point.
   for (int i = 0; i < numDevices; i++) {
-    if (devices[i].is_keyboard && ioctl(devices[i].fd, EVIOCGRAB, 1) < 0) {
+    if ((devices[i].is_keyboard || devices[i].is_mouse) && ioctl(devices[i].fd, EVIOCGRAB, 1) < 0) {
       fprintf(stderr, "EVIOCGRAB failed with error %d\n", errno);
     }
   }


### PR DESCRIPTION
**Description**

My previous PR #737 inadvertedly introduced the issue described in #756.
I didn't notice this before because I don't use a desktop environment on my embedded device.
This PR fixes the issue by also grabbing mouse devices in addition to keyboards.

**Purpose**

Grab mouse devices as well to avoid sending input events to the client desktop while streaming.

@Philosophise, @aandaluz  can you please test if this solves your issue without reverting my previous PR?  Thanks for reporting and appreciate the debugging @aandaluz.