### PR TITLE
Add option for disabling all input (view-only mode) in streaming session

### DIFF
--- a/docs/README.pod
+++ b/docs/README.pod
@@ -149,6 +149,10 @@ Try streaming if GFE version or options are unsupported
 
 Send quit app request to remote after quitting session
 
+=item B<-viewonly>
+
+Disable all input processing (view-only mode)
+
 =item B<-verbose>
 
 Enable verbose output

--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -345,24 +345,24 @@ static bool verifySignature(const char *data, int dataLength, char *signature, i
     BIO* bio = BIO_new(BIO_s_mem());
     BIO_puts(bio, cert);
     x509 = PEM_read_bio_X509(bio, NULL, NULL, NULL);
-    
+
     BIO_free(bio);
-    
+
     if (!x509) {
         return false;
     }
-    
+
     EVP_PKEY* pubKey = X509_get_pubkey(x509);
     EVP_MD_CTX *mdctx = NULL;
     mdctx = EVP_MD_CTX_create();
     EVP_DigestVerifyInit(mdctx, NULL, EVP_sha256(), NULL, pubKey);
     EVP_DigestVerifyUpdate(mdctx, data, dataLength);
     int result = EVP_DigestVerifyFinal(mdctx, signature, signatureLength);
-    
+
     X509_free(x509);
     EVP_PKEY_free(pubKey);
     EVP_MD_CTX_destroy(mdctx);
-    
+
     return result > 0;
 }
 
@@ -618,7 +618,7 @@ int gs_pair(PSERVER_DATA server, char* pin) {
   cleanup:
   if (ret != GS_OK)
     gs_unpair(server);
-  
+
   if (result != NULL)
     free(result);
 

--- a/libgamestream/http.c
+++ b/libgamestream/http.c
@@ -35,15 +35,15 @@ static size_t _write_curl(void *contents, size_t size, size_t nmemb, void *userp
 {
   size_t realsize = size * nmemb;
   PHTTP_DATA mem = (PHTTP_DATA)userp;
- 
+
   mem->memory = realloc(mem->memory, mem->size + realsize + 1);
   if(mem->memory == NULL)
     return 0;
- 
+
   memcpy(&(mem->memory[mem->size]), contents, realsize);
   mem->size += realsize;
   mem->memory[mem->size] = 0;
- 
+
   return realsize;
 }
 
@@ -89,7 +89,7 @@ int http_request(char* url, PHTTP_DATA data) {
     data->size = 0;
   }
   CURLcode res = curl_easy_perform(curl);
-  
+
   if(res != CURLE_OK) {
     gs_error = curl_easy_strerror(res);
     return GS_FAILED;
@@ -99,7 +99,7 @@ int http_request(char* url, PHTTP_DATA data) {
 
   if (debug)
     printf("Response:\n%s\n\n", data->memory);
-  
+
   return GS_OK;
 }
 

--- a/libgamestream/mkcert.c
+++ b/libgamestream/mkcert.c
@@ -39,13 +39,13 @@ CERT_KEY_PAIR mkcert_generate() {
     X509 *x509 = NULL;
     EVP_PKEY *pkey = NULL;
     PKCS12 *p12 = NULL;
-   
+
     CRYPTO_mem_ctrl(CRYPTO_MEM_CHECK_ON);
     bio_err = BIO_new_fp(stderr, BIO_NOCLOSE);
-    
+
     OpenSSL_add_all_algorithms();
     ERR_load_crypto_strings();
-    
+
     mkcert(&x509, &pkey, NUM_BITS, SERIAL, NUM_YEARS);
 
     p12 = PKCS12_create("limelight", "GameStream", pkey, x509, NULL, 0, 0, 0, 0, 0);
@@ -54,9 +54,9 @@ CERT_KEY_PAIR mkcert_generate() {
     ENGINE_cleanup();
 #endif
     CRYPTO_cleanup_all_ex_data();
-    
+
     BIO_free(bio_err);
-    
+
     return (CERT_KEY_PAIR) {x509, pkey, p12};
 }
 
@@ -70,12 +70,12 @@ void mkcert_save(const char* certFile, const char* p12File, const char* keyPairF
     FILE* certFilePtr = fopen(certFile, "w");
     FILE* keyPairFilePtr = fopen(keyPairFile, "w");
     FILE* p12FilePtr = fopen(p12File, "wb");
-    
+
     //TODO: error check
     PEM_write_PrivateKey(keyPairFilePtr, certKeyPair.pkey, NULL, NULL, 0, NULL, NULL);
     PEM_write_X509(certFilePtr, certKeyPair.x509);
     i2d_PKCS12_fp(p12FilePtr, certKeyPair.p12);
-    
+
     fclose(p12FilePtr);
     fclose(certFilePtr);
     fclose(keyPairFilePtr);
@@ -86,7 +86,7 @@ int mkcert(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int years) {
     EVP_PKEY *pk;
     RSA *rsa;
     X509_NAME *name = NULL;
-    
+
     if (*pkeyp == NULL) {
         if ((pk=EVP_PKEY_new()) == NULL) {
             abort();
@@ -95,7 +95,7 @@ int mkcert(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int years) {
     } else {
         pk = *pkeyp;
     }
-    
+
     if (*x509p == NULL) {
         if ((x = X509_new()) == NULL) {
             goto err;
@@ -106,8 +106,8 @@ int mkcert(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int years) {
 
     if ((rsa = RSA_new()) == NULL)
         goto err;
-    
-    BIGNUM* bne = BN_new(); 
+
+    BIGNUM* bne = BN_new();
     if (bne == NULL) {
         abort();
         goto err;
@@ -123,37 +123,37 @@ int mkcert(X509 **x509p, EVP_PKEY **pkeyp, int bits, int serial, int years) {
         abort();
         goto err;
     }
-    
+
     X509_set_version(x, 2);
     ASN1_INTEGER_set(X509_get_serialNumber(x), serial);
     X509_gmtime_adj(X509_get_notBefore(x), 0);
     X509_gmtime_adj(X509_get_notAfter(x), (long)60*60*24*365*years);
     X509_set_pubkey(x, pk);
-    
+
     name = X509_get_subject_name(x);
-    
+
     /* This function creates and adds the entry, working out the
      * correct string type and performing checks on its length.
      */
     X509_NAME_add_entry_by_txt(name,"CN", MBSTRING_ASC, (unsigned char*)"NVIDIA GameStream Client", -1, -1, 0);
-    
+
     /* Its self signed so set the issuer name to be the same as the
      * subject.
      */
     X509_set_issuer_name(x, name);
-    
+
     /* Add various extensions: standard extensions */
     add_ext(x, NID_key_usage, "critical,digitalSignature,keyEncipherment");
-    
+
     add_ext(x, NID_subject_key_identifier, "hash");
-    
+
     if (!X509_sign(x, pk, EVP_sha256())) {
         goto err;
     }
-    
+
     *x509p = x;
     *pkeyp = pk;
-    
+
     return(1);
 err:
     return(0);
@@ -178,7 +178,7 @@ int add_ext(X509 *cert, int nid, char *value)
     if (!ex) {
         return 0;
     }
-    
+
     X509_add_ext(cert, ex, -1);
     X509_EXTENSION_free(ex);
     return 1;

--- a/libgamestream/xml.c
+++ b/libgamestream/xml.c
@@ -132,7 +132,7 @@ static void XMLCALL _xml_write_data(void *userData, const XML_Char *s, int len) 
     search->memory = realloc(search->memory, search->size + len + 1);
     if(search->memory == NULL)
       return;
-  
+
     memcpy(&(search->memory[search->size]), s, len);
     search->size += len;
     search->memory[search->size] = 0;
@@ -162,7 +162,7 @@ int xml_search(char* data, size_t len, char* node, char** result) {
 
   XML_ParserFree(parser);
   *result = search.memory;
-  
+
   return GS_OK;
 }
 

--- a/moonlight.conf
+++ b/moonlight.conf
@@ -43,6 +43,9 @@
 ## Send quit app request to remote after quitting session
 #quitappafter = false
 
+## Disable all input processing (view-only mode)
+#viewonly = false
+
 ## Select audio device to play sound on
 #audio = sysdefault
 

--- a/src/audio/omx.c
+++ b/src/audio/omx.c
@@ -180,16 +180,16 @@ static void omx_renderer_cleanup() {
 static void omx_renderer_decode_and_play_sample(char* data, int length) {
   int decodeLen = opus_multistream_decode(decoder, data, length, pcmBuffer, FRAME_SIZE, 0);
   if (decodeLen > 0) {
-	buf = ilclient_get_input_buffer(component, 100, 1);
+    buf = ilclient_get_input_buffer(component, 100, 1);
     buf->nOffset = 0;
     buf->nFlags = OMX_BUFFERFLAG_TIME_UNKNOWN;
-	int bufLength = decodeLen * sizeof(short) * channelCount;
+    int bufLength = decodeLen * sizeof(short) * channelCount;
     memcpy(buf->pBuffer, pcmBuffer, bufLength);
     buf->nFilledLen = bufLength;
     int r = OMX_EmptyThisBuffer(ilclient_get_handle(component), buf);
     if (r != OMX_ErrorNone) {
-    fprintf(stderr, "Empty buffer error\n");
-    } 
+      fprintf(stderr, "Empty buffer error\n");
+    }
   } else {
     printf("Opus error from decode: %d\n", decodeLen);
   }

--- a/src/config.c
+++ b/src/config.c
@@ -333,7 +333,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   char* config_file = get_path("moonlight.conf", "/etc");
   if (config_file)
     config_file_parse(config_file, config);
-  
+
   if (argc == 2 && access(argv[1], F_OK) == 0) {
     config->action = "stream";
     if (!config_file_parse(argv[1], config))

--- a/src/config.c
+++ b/src/config.c
@@ -251,10 +251,6 @@ bool config_file_parse(char* filename, PCONFIGURATION config) {
         config->address = value;
       } else if (strcmp(key, "sops") == 0) {
         config->sops = strcmp("true", value) == 0;
-      } else if (strcmp(key, "localaudio") == 0) {
-        config->localaudio = strcmp("true", value) == 0;
-      } else if (strcmp(key, "quitappafter") == 0) {
-        config->quitappafter = strcmp("true", value) == 0;
       } else {
         for (int i=0;long_options[i].name != NULL;i++) {
           if (strcmp(long_options[i].name, key) == 0) {

--- a/src/config.c
+++ b/src/config.c
@@ -37,7 +37,7 @@
 
 #define write_config_string(fd, key, value) fprintf(fd, "%s = %s\n", key, value)
 #define write_config_int(fd, key, value) fprintf(fd, "%s = %d\n", key, value)
-#define write_config_bool(fd, key, value) fprintf(fd, "%s = %s\n", key, value?"true":"false");
+#define write_config_bool(fd, key, value) fprintf(fd, "%s = %s\n", key, value ? "true":"false")
 
 bool inputAdded = false;
 
@@ -56,7 +56,7 @@ static struct option long_options[] = {
   {"audio", required_argument, NULL, 'm'},
   {"localaudio", no_argument, NULL, 'n'},
   {"config", required_argument, NULL, 'o'},
-  {"platform", required_argument, 0, 'p'},
+  {"platform", required_argument, NULL, 'p'},
   {"save", required_argument, NULL, 'q'},
   {"keydir", required_argument, NULL, 'r'},
   {"remote", no_argument, NULL, 's'},
@@ -102,7 +102,7 @@ char* get_path(char* name, char* extra_data_dirs) {
   char* end;
   do {
     end = strstr(data_dir, ":");
-    int length = end != NULL?end - data_dir:strlen(data_dir);
+    int length = end != NULL ? end - data_dir:strlen(data_dir);
     memcpy(path, data_dir, length);
     if (path[0] == '/')
       sprintf(path+length, MOONLIGHT_PATH "/%s", name);

--- a/src/config.c
+++ b/src/config.c
@@ -66,6 +66,7 @@ static struct option long_options[] = {
   {"codec", required_argument, NULL, 'x'},
   {"unsupported", no_argument, NULL, 'y'},
   {"quitappafter", no_argument, NULL, '1'},
+  {"viewonly", no_argument, NULL, '2'},
   {"verbose", no_argument, NULL, 'z'},
   {"debug", no_argument, NULL, 'Z'},
   {0, 0, 0, 0},
@@ -216,6 +217,9 @@ static void parse_argument(int c, char* value, PCONFIGURATION config) {
   case '1':
     config->quitappafter = true;
     break;
+  case '2':
+    config->viewonly = true;
+    break;
   case 'z':
     config->debug_level = 1;
     break;
@@ -289,6 +293,8 @@ void config_save(char* filename, PCONFIGURATION config) {
     write_config_bool(fd, "localaudio", config->localaudio);
   if (config->quitappafter)
     write_config_bool(fd, "quitappafter", config->quitappafter);
+  if (config->viewonly)
+    write_config_bool(fd, "viewonly", config->viewonly);
 
   if (strcmp(config->app, "Steam") != 0)
     write_config_string(fd, "app", config->app);
@@ -320,6 +326,7 @@ void config_parse(int argc, char* argv[], PCONFIGURATION config) {
   config->fullscreen = true;
   config->unsupported = false;
   config->quitappafter = false;
+  config->viewonly = false;
   config->codec = CODEC_UNSPECIFIED;
 
   config->inputsCount = 0;

--- a/src/config.h
+++ b/src/config.h
@@ -41,6 +41,7 @@ typedef struct _CONFIGURATION {
   bool fullscreen;
   bool unsupported;
   bool quitappafter;
+  bool viewonly;
   char* inputs[MAX_INPUTS];
   int inputsCount;
   enum codecs codec;

--- a/src/input/cec.c
+++ b/src/input/cec.c
@@ -64,7 +64,7 @@ static void on_cec_keypress(void* userdata, const cec_keypress* key) {
       value = 0;
       break;
   }
-  
+
   if (value != 0) {
     short code = 0x80 << 8 | value;
     LiSendKeyboardEvent(code, (key->duration > 0)?KEY_ACTION_UP:KEY_ACTION_DOWN, 0);
@@ -80,25 +80,25 @@ void cec_init() {
   snprintf(g_config.strDeviceName, sizeof(g_config.strDeviceName), "Moonlight");
   g_config.callbacks = &g_callbacks;
   g_config.deviceTypes.types[0] = CEC_DEVICE_TYPE_PLAYBACK_DEVICE;
-  
+
   if (libcecc_initialise(&g_config, &g_iface, NULL) != 1) {
     fprintf(stderr, "Failed to initialize libcec interface\n");
     fflush(stderr);
     return;
   }
-  
+
   g_iface.init_video_standalone(g_iface.connection);
-  
+
   cec_adapter devices[10];
   int8_t iDevicesFound = g_iface.find_adapters(g_iface.connection, devices, sizeof(devices) / sizeof(devices), NULL);
-  
+
   if (iDevicesFound <= 0) {
     fprintf(stderr, "No CEC devices found\n");
     fflush(stderr);
     libcecc_destroy(&g_iface);
     return;
   }
-  
+
   strcpy(g_strPort, devices[0].comm);
   if (!g_iface.open(g_iface.connection, g_strPort, 5000)) {
     fprintf(stderr, "Unable to open the device on port %s\n", g_strPort);
@@ -106,6 +106,6 @@ void cec_init() {
     libcecc_destroy(&g_iface);
     return;
   }
-  
+
   g_iface.set_active_source(g_iface.connection, g_config.deviceTypes.types[0]);
 }

--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -645,7 +645,7 @@ void evdev_map(char* device) {
   char* buf = str_guid;
   for (int i = 0; i < 16; i++)
     buf += sprintf(buf, "%02x", ((unsigned char*) guid)[i]);
-  
+
   struct mapping map;
   strncpy(map.name, libevdev_get_name(evdev), sizeof(map.name));
   strncpy(map.guid, str_guid, sizeof(map.guid));

--- a/src/input/mapping.h
+++ b/src/input/mapping.h
@@ -28,20 +28,20 @@ struct mapping {
 
   bool reverse_leftx, reverse_lefty;
   bool reverse_rightx, reverse_righty;
-  
+
   short abs_leftx, abs_lefty;
   short abs_rightx, abs_righty;
 
   short hat_dpright, hat_dpleft, hat_dpup, hat_dpdown;
   short hat_dir_dpright, hat_dir_dpleft, hat_dir_dpup, hat_dir_dpdown;
   short btn_dpup, btn_dpdown, btn_dpleft, btn_dpright;
-  
+
   short btn_a, btn_x, btn_y, btn_b;
   short btn_back, btn_start, btn_guide;
   short btn_leftstick, btn_rightstick;
   short btn_leftshoulder, btn_rightshoulder;
-  
-  short abs_lefttrigger, abs_righttrigger; 
+
+  short abs_lefttrigger, abs_righttrigger;
   short btn_lefttrigger, btn_righttrigger;
 
   struct mapping* next;

--- a/src/loop.c
+++ b/src/loop.c
@@ -74,14 +74,14 @@ void loop_add_fd(int fd, FdHandler handler, int events) {
 void loop_remove_fd(int fd) {
   numFds--;
   int fdindex;
-  
+
   for (int i=0;i<numFds;i++) {
     if (fds[i].fd == fd) {
       fdindex = i;
       break;
     }
   }
-  
+
   if (fdindex != numFds && numFds > 0) {
     memcpy(&fds[fdindex], &fds[numFds], sizeof(struct pollfd));
     memcpy(&fdHandlers[fdindex], &fdHandlers[numFds], sizeof(FdHandler));

--- a/src/main.c
+++ b/src/main.c
@@ -211,19 +211,19 @@ int main(int argc, char* argv[]) {
 
   if (config.action == NULL || strcmp("help", config.action) == 0)
     help();
-  
+
   if (config.debug_level > 0)
     printf("Moonlight Embedded %d.%d.%d (%s)\n", VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH, COMPILE_OPTIONS);
 
-  if (strcmp("map", config.action) == 0) { 
+  if (strcmp("map", config.action) == 0) {
     if (config.inputsCount != 1) {
       printf("You need to specify one input device using -input.\n");
       exit(-1);
     }
- 
+
     evdev_create(config.inputs[0], NULL, config.debug_level > 0);
-    evdev_map(config.inputs[0]); 
-    exit(0); 
+    evdev_map(config.inputs[0]);
+    exit(0);
   }
 
   if (config.address == NULL) {
@@ -240,7 +240,7 @@ int main(int argc, char* argv[]) {
       exit(-1);
     }
   }
-  
+
   char host_config_file[128];
   sprintf(host_config_file, "hosts/%s.conf", config.address);
   if (access(host_config_file, R_OK) != -1)

--- a/src/main.c
+++ b/src/main.c
@@ -178,7 +178,7 @@ static void help() {
   printf("\t-remote\t\t\tEnable remote optimizations\n");
   printf("\t-app <app>\t\tName of app to stream\n");
   printf("\t-nosops\t\t\tDon't allow GFE to modify game settings\n");
-  printf("\t-localaudio\t\tPlay audio locally\n");
+  printf("\t-localaudio\t\tPlay audio locally on the host computer\n");
   printf("\t-surround\t\tStream 5.1 surround sound (requires GFE 2.7)\n");
   printf("\t-keydir <directory>\tLoad encryption keys from directory\n");
   printf("\t-mapping <file>\t\tUse <file> as gamepad mappings configuration file\n");

--- a/src/video/egl.c
+++ b/src/video/egl.c
@@ -139,7 +139,7 @@ void egl_init(EGLNativeDisplayType native_display, NativeWindowType native_windo
   glGenBuffers(1, &ebo);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ebo);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(elements), elements, GL_STATIC_DRAW);
-  
+
   GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);
   glShaderSource(vertex_shader, 1, &vertex_source, NULL);
   glCompileShader(vertex_shader);

--- a/src/video/ffmpeg.c
+++ b/src/video/ffmpeg.c
@@ -170,6 +170,6 @@ int ffmpeg_decode(unsigned char* indata, int inlen) {
     av_strerror(err, errorstring, sizeof(errorstring));
     fprintf(stderr, "Decode failed - %s\n", errorstring);
   }
-  
+
   return err < 0 ? err : 0;
 }

--- a/src/video/ffmpeg.h
+++ b/src/video/ffmpeg.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of Moonlight Embedded.
- * 
+ *
  * Based on Moonlight Pc implementation
  *
  * Moonlight is free software; you can redistribute it and/or modify

--- a/src/video/ffmpeg_vaapi.c
+++ b/src/video/ffmpeg_vaapi.c
@@ -46,7 +46,7 @@ static enum AVPixelFormat va_get_format(AVCodecContext* context, const enum AVPi
     fprintf(stderr, "Failed to initialize VAAPI frame context");
     return AV_PIX_FMT_NONE;
   }
-  
+
   context->pix_fmt = AV_PIX_FMT_VAAPI;
   context->hw_device_ctx = device_ref;
   context->hw_frames_ctx = hw_ctx;

--- a/src/video/imx.c
+++ b/src/video/imx.c
@@ -139,11 +139,11 @@ static int decoder_renderer_setup(int videoFormat, int width, int height, int re
   }
 
   close(fd_fb);
-  
+
   int regfbcount = MIN_FRAME_BUFFER_COUNT + 2;
   int picWidth = ((width + 15) & ~15);
   int picHeight = ((height + 15) & ~15);
-  
+
   char v4l_device[16];
   sprintf(v4l_device, "/dev/video%d", 17);
   fd = open(v4l_device, O_RDWR, 0);
@@ -192,7 +192,7 @@ static int decoder_renderer_setup(int videoFormat, int width, int height, int re
     fprintf(stderr, "Not enough video buffers\n");
     return -2;
   }
-    
+
   for (int i = 0; i < regfbcount; i++) {
     struct v4l2_buffer buffer = {0};
     struct vpu_buf *buf;
@@ -233,7 +233,7 @@ static int decoder_renderer_setup(int videoFormat, int width, int height, int re
       return -2;
     }
   }
-  
+
   vpu_setup(buffers, regfbcount, width, height);
 
   if (pipe(pipefd) == -1 || pipe(clearpipefd) == -1) {

--- a/src/video/imx_vpu.c
+++ b/src/video/imx_vpu.c
@@ -143,7 +143,7 @@ void vpu_setup(struct vpu_buf* buffers[], int bufferCount, int width, int height
     }
     fb[i].bufMvCol = mvcol_md[i].phy_addr;
   }
-    
+
   bufinfo.avcSliceBufInfo.bufferBase = slice_mem_desc.phy_addr;
   bufinfo.avcSliceBufInfo.bufferSize = phy_slicebuf_size;
 
@@ -237,7 +237,7 @@ bool vpu_decode(PDECODE_UNIT decodeUnit) {
     fprintf(stderr, "Failed to decode frame\n");
     exit(EXIT_FAILURE);
   }
-  
+
   currentFrame = outinfo.indexFrameDisplay;
   return true;
 }
@@ -249,7 +249,7 @@ void vpu_clear(int disp_clr_index) {
 void vpu_cleanup() {
   IOFreePhyMem(&ps_mem_desc);
   IOFreePhyMem(&slice_mem_desc);
-  
+
   IOFreeVirtMem(&mem_desc);
   IOFreePhyMem(&mem_desc);
   vpu_UnInit();

--- a/src/video/sdl.c
+++ b/src/video/sdl.c
@@ -39,7 +39,7 @@ static int sdl_setup(int videoFormat, int width, int height, int redrawRate, voi
     fprintf(stderr, "Couldn't initialize video decoding\n");
     return -1;
   }
-  
+
   ffmpeg_buffer = malloc(DECODER_BUFFER_SIZE + AV_INPUT_BUFFER_PADDING_SIZE);
   if (ffmpeg_buffer == NULL) {
     fprintf(stderr, "Not enough memory\n");

--- a/src/video/x11.c
+++ b/src/video/x11.c
@@ -57,7 +57,7 @@ static int frame_handle(int pipefd) {
   if (frame) {
     if (ffmpeg_decoder == SOFTWARE)
       egl_draw(frame->data);
-    #ifdef HAVE_VAAPI 
+    #ifdef HAVE_VAAPI
     else if (ffmpeg_decoder == VAAPI)
       vaapi_queue(frame, window, display_width, display_height);
     #endif


### PR DESCRIPTION
**Description**

This PR adds a new option to enable a "view-only" mode, that is, for Moonlight embedded to not send any input back to the host computer and just act as a remote viewer.

NOTE: at the moment this is only implemented for embedded and SDL platforms, not for X11 due to the way the latter's input system is implemented. I may implement for X11 in the future.

I tested this on a Raspberry Pi device only (embedded case), but it should work on SDL-based devices as well. Testing on these is appreciated.

I also cleaned-up a bit some parts of the codebase for consistency, indentation and trailing spaces. Please let me know if you would prefer these changes in a separate PR instead.

Closes #761 

**Purpose**

This feature has been requested in the RetroPie forums from users that use the [Virtual Here](https://www.virtualhere.com/) software, which allows for USB devices on a system (e.g. embedded computer) to be available on another system (e.g. gaming host computer) via network. For these users this alternative is more flexible and seems to work better than the internal Moonlight input system. To use such software, Moonlight should not initialise nor use any input devices connected to the system, therefore the purpose of this new option.

Another use case has been described in the feature request in #761, where input is done directly on the host computer, therefore input from Moonlight embedded is not desired.
