### PR TITLE
Avoid remote stuck keys on disconnect

### DIFF
--- a/src/input/evdev.c
+++ b/src/input/evdev.c
@@ -229,8 +229,12 @@ static bool evdev_handle_event(struct input_event *ev, struct input_device *dev)
       // Quit the stream if all the required quit keys are down
       if ((dev->modifiers & ACTION_MODIFIERS) == ACTION_MODIFIERS &&
           ev->code == QUIT_KEY && ev->value != 0) {
-        return false;
-      }
+      
+      short code = 0x80 << 8 | keyCodes[ev->code];
+      LiSendKeyboardEvent(code, KEY_ACTION_DOWN, 0);
+      usleep(1000000);
+      return false;
+    }
 
       short code = 0x80 << 8 | keyCodes[ev->code];
       LiSendKeyboardEvent(code, ev->value?KEY_ACTION_DOWN:KEY_ACTION_UP, dev->modifiers);


### PR DESCRIPTION

**Description**
we have detected that with geforce experience 3.17, sometimes disconnecting from the remote host with the CTRL+ALT+SHIFT+Q leaves the keyboard stuck with  key up state. For instance If you were streaming windows desktop and disconnect, sometimes  double clicking will not work, as the local host will believe that the shift key is still pressed , so it will show the file properties dialog instead.

This is similar to what other people reported with protocols such as VNC in the past. See   https://github.com/TigerVNC/tigervnc/issues/345 for instnace. Probably also related to https://github.com/irtimmer/moonlight-embedded/issues/766

If we connect a keyboard in the remote PC and press twice the ALT or CTrl keys, then we keyboard state is cleared and works fine again 

**Purpose**
This patch sends a keydown event after the CTRL+ALT+SHIFT+Q combination and waits 1 second for it to be processed, so that it never leaves the remote in a stuck keys state on disconnect.


