### PR TITLE
Fix surround sound on a resumed session

### DIFF
--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -45,12 +45,6 @@
 #define UNIQUEID_BYTES 8
 #define UNIQUEID_CHARS (UNIQUEID_BYTES*2)
 
-#define CHANNEL_COUNT_STEREO 2
-#define CHANNEL_COUNT_51_SURROUND 6
-
-#define CHANNEL_MASK_STEREO 0x3
-#define CHANNEL_MASK_51_SURROUND 0xFC
-
 static char unique_id[UNIQUEID_CHARS+1];
 static X509 *cert;
 static char cert_hex[4096];
@@ -692,13 +686,12 @@ int gs_start_app(PSERVER_DATA server, STREAM_CONFIGURATION *config, int appId, b
 
   uuid_generate_random(uuid);
   uuid_unparse(uuid, uuid_str);
+  int surround_info = SURROUNDAUDIOINFO_FROM_AUDIO_CONFIGURATION(config->audioConfiguration);
   if (server->currentGame == 0) {
-    int channelCounnt = config->audioConfiguration == AUDIO_CONFIGURATION_STEREO ? CHANNEL_COUNT_STEREO : CHANNEL_COUNT_51_SURROUND;
-    int mask = config->audioConfiguration == AUDIO_CONFIGURATION_STEREO ? CHANNEL_MASK_STEREO : CHANNEL_MASK_51_SURROUND;
     int fps = sops && config->fps > 60 ? 60 : config->fps; 
-    snprintf(url, sizeof(url), "https://%s:47984/launch?uniqueid=%s&uuid=%s&appid=%d&mode=%dx%dx%d&additionalStates=1&sops=%d&rikey=%s&rikeyid=%d&localAudioPlayMode=%d&surroundAudioInfo=%d&remoteControllersBitmap=%d&gcmap=%d", server->serverInfo.address, unique_id, uuid_str, appId, config->width, config->height, fps, sops, rikey_hex, rikeyid, localaudio, (mask << 16) + channelCounnt, gamepad_mask, gamepad_mask);
+    snprintf(url, sizeof(url), "https://%s:47984/launch?uniqueid=%s&uuid=%s&appid=%d&mode=%dx%dx%d&additionalStates=1&sops=%d&rikey=%s&rikeyid=%d&localAudioPlayMode=%d&surroundAudioInfo=%d&remoteControllersBitmap=%d&gcmap=%d", server->serverInfo.address, unique_id, uuid_str, appId, config->width, config->height, fps, sops, rikey_hex, rikeyid, localaudio, surround_info, gamepad_mask, gamepad_mask);
   } else
-    snprintf(url, sizeof(url), "https://%s:47984/resume?uniqueid=%s&uuid=%s&rikey=%s&rikeyid=%d", server->serverInfo.address, unique_id, uuid_str, rikey_hex, rikeyid);
+    snprintf(url, sizeof(url), "https://%s:47984/resume?uniqueid=%s&uuid=%s&rikey=%s&rikeyid=%d&surroundAudioInfo=%d", server->serverInfo.address, unique_id, uuid_str, rikey_hex, rikeyid, surround_info);
 
   if ((ret = http_request(url, data)) == GS_OK)
     server->currentGame = appId;


### PR DESCRIPTION
**Description**
The `surroundAudioInfo` parameter needs to be provided on `/resume` also, otherwise the stream will be forced to stereo and a `No surround parameters found` error will be emitted from moonlight-common-c when establishing the RTSP connection.

I also took advantage of the new `SURROUNDAUDIOINFO_FROM_AUDIO_CONFIGURATION()` in moonlight-common-c to avoid hardcoding surround audio parameters.

**Purpose**
Fix surround sound audio when resuming a previously launched session.