### PR TITLE
Fix gcc-10 compilation (fno-common flag enabled by default)

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -48,7 +48,7 @@ typedef struct _CONFIGURATION {
   enum codecs codec;
 } CONFIGURATION, *PCONFIGURATION;
 
-bool inputAdded;
+extern bool inputAdded;
 
 bool config_file_parse(char* filename, PCONFIGURATION config);
 void config_parse(int argc, char* argv[], PCONFIGURATION config);

--- a/src/sdl.h
+++ b/src/sdl.h
@@ -36,7 +36,7 @@
 void sdl_init(int width, int height, bool fullscreen);
 void sdl_loop();
 
-SDL_mutex *mutex;
-int sdlCurrentFrame, sdlNextFrame;
+extern SDL_mutex *mutex;
+extern int sdlCurrentFrame, sdlNextFrame;
 
 #endif /* HAVE_SDL */


### PR DESCRIPTION
**Description**
This PR changes a few variables to "extern" where they should be declared as extern.

**Purpose**
Have moonlight-embedded compile fine using GCC 10 since it has enabled stricter checks on extern symbols (-fcommon by default).

Tested building OK on Linux x86_64 (Ubuntu 20.04 LTS) using both GCC 9.3 and GCC 10.1