### PR TITLE
Randomized input IV

### DIFF
--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -670,10 +670,14 @@ int gs_start_app(PSERVER_DATA server, STREAM_CONFIGURATION *config, int appId, b
 
   RAND_bytes(config->remoteInputAesKey, 16);
   memset(config->remoteInputAesIv, 0, 16);
+  // GFE somehow doesn't like this totally legit random number, so we have to generate one
+  RAND_bytes(config->remoteInputAesIv, 4);
 
   srand(time(NULL));
   char url[4096];
   u_int32_t rikeyid = 0;
+  memset(&rikeyid, config->remoteInputAesIv, 4);
+  rikeyid = htonl(rikeyid);
   char rikey_hex[33];
   bytes_to_hex(config->remoteInputAesKey, rikey_hex, 16);
 

--- a/libgamestream/client.c
+++ b/libgamestream/client.c
@@ -30,6 +30,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
+#include <arpa/inet.h>
 #include <uuid/uuid.h>
 #include <openssl/sha.h>
 #include <openssl/aes.h>


### PR DESCRIPTION
**Description**

This PR added randomized IV (4 bytes followed 0s) and correct `rikeyid` accepted by latest GFE software.

**Purpose**

After updating moonlight-common-c, user may experience audio issue if audio encryption is enabled. This is the fix provided by @cgutman .
